### PR TITLE
Fix Flaky Test & Faraday warnings

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@ class HomeController < ApplicationController
   def home
     authorize Tournament, :index?
 
-    @tournaments = Tournament.where(date: Date.today, private: false)
+    @tournaments = Tournament.where(date: Date.current, private: false)
   end
 
   def help

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -38,7 +38,7 @@ class TournamentsController < ApplicationController
     authorize Tournament
 
     @new_tournament = current_user.tournaments.new
-    @new_tournament.date = Date.today
+    @new_tournament.date = Date.current
   end
 
   def create

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -71,7 +71,7 @@ class Tournament < ApplicationRecord
   private
 
   def default_date
-    self.date = Date.today
+    self.date = Date.current
   end
 
   def create_stage

--- a/app/services/abr_upload.rb
+++ b/app/services/abr_upload.rb
@@ -19,7 +19,7 @@ class AbrUpload
     Faraday.new do |conn|
       conn.request :multipart
       conn.adapter :net_http
-      conn.basic_auth 'cobra', Rails.application.secrets.abr_auth
+      conn.request :basic_auth, 'cobra', Rails.application.secrets.abr_auth
     end.post endpoint do |req|
       upload = Faraday::UploadIO.new(StringIO.new(json), 'text/json')
       req.body = { jsonresults: upload }

--- a/spec/feature/home/list_todays_tournaments_spec.rb
+++ b/spec/feature/home/list_todays_tournaments_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "list today's tournaments" do
   let!(:today) do
-    create(:tournament, date: Date.today, name: 'TodayGNK', slug: 'TEST')
+    create(:tournament, date: Date.current.beginning_of_day, name: 'TodayGNK', slug: 'TEST')
   end
 
   before do
-    create(:tournament, date: Date.yesterday, name: 'YesterdayGNK', slug: '1234')
-    create(:tournament, date: Date.tomorrow, name: 'TomorrowGNK', slug: '5678')
-    create(:tournament, date: Date.today, name: 'PrivateGNK', private: true)
+    create(:tournament, date: Date.yesterday.beginning_of_day, name: 'YesterdayGNK', slug: '1234')
+    create(:tournament, date: Date.tomorrow.beginning_of_day, name: 'TomorrowGNK', slug: '5678')
+    create(:tournament, date: Date.current.beginning_of_day, name: 'PrivateGNK', private: true)
 
     visit root_path
   end

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Tournament do
   end
 
   it 'automatically populates date' do
-    expect(tournament.date).to eq(Date.today)
+    expect(tournament.date).to eq(Date.current)
   end
 
   it 'automatically creates stage' do


### PR DESCRIPTION
"Today's tournaments" test was flaky due to Date.today (not TZ aware, apparently) vs. Date.yesterday/Date.today (which are TZ aware):
```
Loading development environment (Rails 5.2.6)
irb(main):001:0> Date.yesterday
=> Mon, 27 Sep 2021
irb(main):002:0> Date.today
=> Mon, 27 Sep 2021
irb(main):003:0> Date.tomorrow
=> Wed, 29 Sep 2021
```

Fixes warning in the test suite:
```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed
in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```