### PR TITLE
Simple caching

### DIFF
--- a/app/models/pairing.rb
+++ b/app/models/pairing.rb
@@ -1,5 +1,5 @@
 class Pairing < ApplicationRecord
-  belongs_to :round
+  belongs_to :round, touch: true
   belongs_to :player1, class_name: 'Player', optional: true
   belongs_to :player2, class_name: 'Player', optional: true
   has_one :tournament, through: :round

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -1,12 +1,12 @@
 class Round < ApplicationRecord
-  belongs_to :stage
+  belongs_to :stage, touch: true
   has_one :tournament, through: :stage
   has_many :pairings, -> { order(:table_number) }, dependent: :destroy
 
   default_scope { order(number: :asc) }
   scope :complete, -> { where(completed: true) }
 
-  after_update_commit :cache_standings!, if: Proc.new { saved_change_to_completed? && completed? }
+  after_update :cache_standings!, if: Proc.new { saved_change_to_completed? && completed? }
   delegate :cache_standings!, to: :stage
 
   def pair!

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,5 +1,5 @@
 class Stage < ApplicationRecord
-  belongs_to :tournament
+  belongs_to :tournament, touch: true
   has_many :rounds, dependent: :destroy
   has_many :registrations, dependent: :destroy
   has_many :players, through: :registrations

--- a/app/views/rounds/_round.html.slim
+++ b/app/views/rounds/_round.html.slim
@@ -1,5 +1,5 @@
-- if round.stage.players.count < 100 || round == @tournament.stages.last.rounds.last
-  - cache_unless user_signed_in?, round do
+- if round.stage.players.count < 100 || round.id == @tournament.stages.last.rounds.last.id
+  - cache_unless user_signed_in?, [round, @tournament.stages.last] do
     .card
       .card-header role="tab"
         .row

--- a/app/views/rounds/_round.html.slim
+++ b/app/views/rounds/_round.html.slim
@@ -1,27 +1,28 @@
 - if round.stage.players.count < 100 || round == @tournament.stages.last.rounds.last
-  .card
-    .card-header role="tab"
-      .row
-        .col-sm-9
-          a data-toggle="collapse" href="#round#{round.id}"
-            h5.mb-0 Round #{round.number}
-        .col-sm-3
-          | #{round.pairings.reported.count} / #{round.pairings.count} pairings reported
-
-    .collapse id="round#{round.id}" class=("show" if round == @tournament.stages.last.rounds.last)
-      .col-12.my-3
-        - if policy(round.tournament).edit?
-          = link_to tournament_round_path(round.tournament, round), class: 'btn btn-warning' do
-            => fa_icon 'pencil'
-            | Edit
-          - unless round.completed?
-            =< link_to complete_tournament_round_path(round.tournament, round, completed: true), method: :patch, class: 'btn btn-warning' do
-              => fa_icon 'check'
-              | Complete
-          =< link_to match_slips_tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
-            => fa_icon 'flag-checkered'
-            | Match slips
-        =< link_to tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
-          => fa_icon 'list-ul'
-          | Pairings by name
-        = render 'pairings', round: round
+  - cache_unless user_signed_in?, round do
+    .card
+      .card-header role="tab"
+        .row
+          .col-sm-9
+            a data-toggle="collapse" href="#round#{round.id}"
+              h5.mb-0 Round #{round.number}
+          .col-sm-3
+            | #{round.pairings.reported.count} / #{round.pairings.count} pairings reported
+  
+      .collapse id="round#{round.id}" class=("show" if round.id == @tournament.stages.last.rounds.last.id)
+        .col-12.my-3
+          - if policy(round.tournament).edit?
+            = link_to tournament_round_path(round.tournament, round), class: 'btn btn-warning' do
+              => fa_icon 'pencil'
+              | Edit
+            - unless round.completed?
+              =< link_to complete_tournament_round_path(round.tournament, round, completed: true), method: :patch, class: 'btn btn-warning' do
+                => fa_icon 'check'
+                | Complete
+            =< link_to match_slips_tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
+              => fa_icon 'flag-checkered'
+              | Match slips
+          =< link_to tournament_round_pairings_path(round.tournament, round), class: 'btn btn-primary' do
+            => fa_icon 'list-ul'
+            | Pairings by name
+          = render 'pairings', round: round

--- a/db/migrate/20211003030446_add_updated_at_to_rounds_and_pairings.rb
+++ b/db/migrate/20211003030446_add_updated_at_to_rounds_and_pairings.rb
@@ -1,0 +1,6 @@
+class AddUpdatedAtToRoundsAndPairings < ActiveRecord::Migration[5.2]
+  def change
+    add_timestamps :rounds, null: false, default: -> { 'NOW()' }
+    add_timestamps :pairings, null: false, default: -> { 'NOW()' }
+  end
+end

--- a/db/migrate/20211013035935_add_updated_at_to_stage_and_tournament.rb
+++ b/db/migrate/20211013035935_add_updated_at_to_stage_and_tournament.rb
@@ -1,6 +1,6 @@
 class AddUpdatedAtToStageAndTournament < ActiveRecord::Migration[5.2]
   def change
     add_timestamps :stages, null: false, default: -> { 'NOW()' }
-    add_column :tournaments, :updated_at, :datetime
+    add_column :tournaments, :updated_at, :datetime, null: false, default: -> { 'NOW()' }
   end
 end

--- a/db/migrate/20211013035935_add_updated_at_to_stage_and_tournament.rb
+++ b/db/migrate/20211013035935_add_updated_at_to_stage_and_tournament.rb
@@ -1,0 +1,6 @@
+class AddUpdatedAtToStageAndTournament < ActiveRecord::Migration[5.2]
+  def change
+    add_timestamps :stages, null: false, default: -> { 'NOW()' }
+    add_column :tournaments, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_135125) do
+ActiveRecord::Schema.define(version: 2021_10_03_030446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,15 +22,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_135125) do
     t.string "nrdb_code"
     t.string "autocomplete"
     t.index ["side"], name: "index_identities_on_side"
-  end
-
-  create_table "notifications", id: :serial, force: :cascade do |t|
-    t.string "message"
-    t.integer "notification_type"
-    t.integer "tournament_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["tournament_id"], name: "index_notifications_on_tournament_id"
   end
 
   create_table "pairings", id: :serial, force: :cascade do |t|
@@ -45,6 +36,8 @@ ActiveRecord::Schema.define(version: 2020_06_24_135125) do
     t.integer "score1_corp"
     t.integer "score2_corp"
     t.integer "score2_runner"
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["player1_id"], name: "index_pairings_on_player1_id"
     t.index ["player2_id"], name: "index_pairings_on_player2_id"
     t.index ["round_id"], name: "index_pairings_on_round_id"
@@ -59,7 +52,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_135125) do
     t.integer "seed"
     t.boolean "first_round_bye", default: false
     t.integer "previous_id"
-    t.boolean "deck_checked"
     t.integer "manual_seed"
     t.index ["tournament_id"], name: "index_players_on_tournament_id"
   end
@@ -78,6 +70,8 @@ ActiveRecord::Schema.define(version: 2020_06_24_135125) do
     t.boolean "completed", default: false
     t.decimal "weight", default: "1.0"
     t.integer "stage_id"
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["stage_id"], name: "index_rounds_on_stage_id"
     t.index ["tournament_id"], name: "index_rounds_on_tournament_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 2021_10_13_035935) do
     t.boolean "private", default: false
     t.string "stream_url"
     t.boolean "manual_seed"
-    t.datetime "updated_at"
+    t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["user_id"], name: "index_tournaments_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_030446) do
+ActiveRecord::Schema.define(version: 2021_10_13_035935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 2021_10_03_030446) do
     t.integer "tournament_id"
     t.integer "number", default: 1
     t.integer "format", default: 0, null: false
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["tournament_id"], name: "index_stages_on_tournament_id"
   end
 
@@ -108,6 +110,7 @@ ActiveRecord::Schema.define(version: 2021_10_03_030446) do
     t.boolean "private", default: false
     t.string "stream_url"
     t.boolean "manual_seed"
+    t.datetime "updated_at"
     t.index ["user_id"], name: "index_tournaments_on_user_id"
   end
 


### PR DESCRIPTION
This *almost* works just as i want it.

In the template, the @tournament.stages.last.rounds.last.id comparison appears to stay cached so the prior round is not collapsed when the new round is paired.

![Screenshot 2021-10-12 8 18 17 PM](https://user-images.githubusercontent.com/396562/137050315-b4744a2a-2467-4d60-a217-230ac9569767.png)


All the other updates appear to refresh the cache properly.