### PR TITLE
Update docker config to link source files instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cobra
 cobra_test
 
 public/scoop.png
+/public/assets/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,6 @@ RUN gem install bundler
 # Finish establishing our Ruby enviornment
 RUN bundle install
 
-# Copy the Rails application into place
-COPY . .
-
-RUN bundle exec rake assets:precompile
-
 # Define the script we want run once the container boots
 # Use the "exec" form of CMD so our script shuts down gracefully on SIGTERM (i.e. `docker stop`)
 CMD [ "config/containers/app_cmd.sh" ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker-compose up -d db
 docker-compose exec db psql --username=postgres -c "create user cobra with password '' CREATEDB;"
 docker-compose run app rake db:create db:migrate 
 docker-compose run app rake ids:update 
+docker-compose run app bundle exec rake assets:precompile
 docker-compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - db
 
     volumes:
+      - .:/var/www/cobra/
       - cobra-logs:/var/www/cobra/log
 
   # service configuration for our database


### PR DESCRIPTION
After doing this, using docker for local development becomes easier because the source is linked, not copied.

This also cuts down on some unnecessary docker build times.

We could definitely consider changing this for production use cases.