### PR TITLE
Fix a warning from Pundit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  include Pundit
+  include Pundit::Authorization
   after_action :verify_authorized
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorised
   rescue_from ActiveRecord::RecordNotFound, with: :error


### PR DESCRIPTION
Fixes this warning in the tests:

DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.                                                                                    
 (called from include at /var/www/cobra/app/controllers/application_controller.rb:4)
