### PR TITLE
Players can update registration 

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -27,11 +27,15 @@ class PlayersController < ApplicationController
   end
 
   def update
-    authorize @tournament, :update?
+    authorize @tournament, :register?
 
     @player.update(player_params)
 
-    redirect_to tournament_players_path(@tournament)
+    if current_user.id == @tournament.user_id
+      redirect_to tournament_players_path(@tournament)
+    else
+      redirect_to tournament_path(@tournament)
+    end
   end
 
   def destroy

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -1,7 +1,7 @@
 class TournamentsController < ApplicationController
   before_action :set_tournament, only: [
       :show, :edit, :update, :destroy,
-      :upload_to_abr, :save_json, :cut, :qr
+      :upload_to_abr, :save_json, :cut, :qr, :registration
     ]
 
   def index
@@ -23,19 +23,29 @@ class TournamentsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @players = @tournament.players.active.sort_by { |p| p.name || '' }
-        @dropped = @tournament.players.dropped.sort_by { |p| p.name || '' }
-
-        if current_user
-          @current_user_is_running_tournament = @tournament.user_id == current_user.id
-          @current_user_player = @players.find { |p| p.user_id == current_user.id }
-          @current_user_dropped = @dropped.any? { |p| p.user_id == current_user.id }
-        end
+        set_tournament_view_data
       end
       format.json do
         headers['Access-Control-Allow-Origin'] = '*'
         render json: NrtmJson.new(@tournament).data(tournament_url(@tournament.slug, @request))
       end
+    end
+  end
+
+  def registration
+    authorize @tournament, :register?
+
+    set_tournament_view_data
+  end
+
+  def set_tournament_view_data
+    @players = @tournament.players.active.sort_by { |p| p.name || '' }
+    @dropped = @tournament.players.dropped.sort_by { |p| p.name || '' }
+
+    if current_user
+      @current_user_is_running_tournament = @tournament.user_id == current_user.id
+      @current_user_player = @players.find { |p| p.user_id == current_user.id }
+      @current_user_dropped = @dropped.any? { |p| p.user_id == current_user.id }
     end
   end
 

--- a/app/policies/tournament_policy.rb
+++ b/app/policies/tournament_policy.rb
@@ -19,6 +19,10 @@ class TournamentPolicy < ApplicationPolicy
     update?
   end
 
+  def register?
+    record.self_registration || update?
+  end
+
   def save_json?
     show?
   end

--- a/app/views/tournaments/_overview_card.html.slim
+++ b/app/views/tournaments/_overview_card.html.slim
@@ -1,0 +1,26 @@
+.col-md-6
+  .card
+    ul.list-group.list-group-flush
+      - if @tournament.slug
+        li.list-group-item
+          .small.text-secondary Shortcode:
+          | #{@tournament.slug} (
+          = link_to tournament_url(@tournament.slug, request), tournament_url(@tournament.slug, request)
+          | )
+
+      li.list-group-item
+        .small.text-secondary Organiser:
+        | #{@tournament.user.nrdb_username}
+      li.list-group-item
+        .small.text-secondary Players:
+        => pluralize(@players.count, 'active player')
+        | (#{@dropped.count} dropped)
+      - if policy(@tournament).edit?
+        li.list-group-item
+          .small.text-secondary
+            | QR Code:
+          .row
+            .col-sm-6
+              = link_to qr_tournament_path(@tournament), :target => '_blank' do
+                => fa_icon 'qrcode'
+                | Open Printable QR Code

--- a/app/views/tournaments/_player_counts.html.slim
+++ b/app/views/tournaments/_player_counts.html.slim
@@ -1,0 +1,24 @@
+- if @tournament.rounds.any? || policy(@tournament).edit?
+  .col-12.mt-3.row
+    .col-md-6
+      table.table
+        thead
+          tr
+            th Corp
+            th Players
+        tbody
+          - @tournament.corp_counts.each do |id, count|
+            tr
+              td= render id
+              td= count
+    .col-md-6
+      table.table
+        thead
+          tr
+            th Runner
+            th Players
+        tbody
+          - @tournament.runner_counts.each do |id, count|
+            tr
+              td= render id
+              td= count

--- a/app/views/tournaments/registration.html.slim
+++ b/app/views/tournaments/registration.html.slim
@@ -1,0 +1,20 @@
+= render 'overview_card'
+
+.col-md-6
+  .card
+    .card-header
+      .d-flex.justify-content-between
+        h5.mb-0 My Registration Information
+        = link_to tournament_path(@tournament), title: 'Cancel', class: 'float-right' do
+          => fa_icon 'undo'
+          span.d-none Cancel registration edits
+    .card-body
+      = simple_form_for @current_user_player, url: tournament_player_path(@tournament, @current_user_player) do |f|
+        = render 'players/form', f: f
+        .text-right
+          = button_tag type: :submit, class: 'btn btn-primary' do
+            => fa_icon 'check'
+            | Update
+
+
+= render 'player_counts'

--- a/app/views/tournaments/show.html.slim
+++ b/app/views/tournaments/show.html.slim
@@ -1,35 +1,15 @@
-.col-md-6
-  .card
-    ul.list-group.list-group-flush
-      - if @tournament.slug
-        li.list-group-item
-          .small.text-secondary Shortcode:
-          | #{@tournament.slug} (
-          = link_to tournament_url(@tournament.slug, request), tournament_url(@tournament.slug, request)
-          | )
-
-      li.list-group-item
-        .small.text-secondary Organiser:
-        | #{@tournament.user.nrdb_username}
-      li.list-group-item
-        .small.text-secondary Players:
-        => pluralize(@players.count, 'active player')
-        | (#{@dropped.count} dropped)
-      - if policy(@tournament).edit?
-        li.list-group-item
-          .small.text-secondary
-            | QR Code:
-          .row
-            .col-sm-6
-              = link_to qr_tournament_path(@tournament), :target => '_blank' do
-                => fa_icon 'qrcode'
-                | Open Printable QR Code
+= render 'overview_card'
 
 .col-md-6
   - if @current_user_player
     .card
       .card-header
-        h5.card-title.mb-0 My Registration Information
+				.d-flex.justify-content-between
+					h5.mb-0 My Registration Information
+					- if policy(@tournament).register?
+						= link_to registration_tournament_path(@tournament), title: 'Edit', class: 'float-right' do
+							=> fa_icon 'pencil'
+							span.d-none Edit my registration information
       ul.list-group.list-group-flush
         li.list-group-item
           .small.text-secondary Name:
@@ -49,27 +29,25 @@
   - else
     - if @tournament.self_registration?
       - if current_user
-        - unless @current_user_player
-          .card.alert.alert-secondary
-            .card-body
-              - unless @current_user_dropped
-                h5.card-title Register for this Event
-                = simple_form_for :player, url: tournament_players_path(@tournament) do |f|
-                  = render 'players/form', f: f, default_name: current_user ? current_user.nrdb_username : ''
-                  .text-right
-                    = button_tag type: :submit, class: 'btn btn-primary', disabled: (not current_user) do
-                      => fa_icon 'user-plus'
-                      | Register
-              - else
-                h5.card-title Rejoin this Event
-                - if @current_user_is_running_tournament
-                  p
-                    | You can re-instate yourself on the
-                    =<> link_to tournament_players_path(@tournament) do
-                      | Players
-                    | tab.
-                - else
-                  p Talk to a Tournmanet Organiser to rejoin the event
+				.card.alert.alert-secondary
+					- unless @current_user_dropped
+						h5.card-title Register for this Event
+						= simple_form_for :player, url: tournament_players_path(@tournament) do |f|
+							= render 'players/form', f: f, default_name: current_user ? current_user.nrdb_username : ''
+							.text-right
+								= button_tag type: :submit, class: 'btn btn-primary', disabled: (not current_user) do
+									=> fa_icon 'user-plus'
+									| Register
+					- else
+						h5.card-title Rejoin this Event
+						- if @current_user_is_running_tournament
+							p
+								| You can re-instate yourself on the
+								=<> link_to tournament_players_path(@tournament) do
+									| Players
+								| tab.
+						- else
+							p Talk to a Tournmanet Organiser to rejoin the event
       - else
         .card.alert.alert-warning
           .card-body
@@ -84,28 +62,4 @@
               span.icon.icon-link
               | &nbsp;Create NRDB account
 
-
-- if @tournament.rounds.any? || policy(@tournament).edit?
-  .col-12.mt-3.row
-    .col-md-6
-      table.table
-        thead
-          tr
-            th Corp
-            th Players
-        tbody
-          - @tournament.corp_counts.each do |id, count|
-            tr
-              td= render id
-              td= count
-    .col-md-6
-      table.table
-        thead
-          tr
-            th Runner
-            th Players
-        tbody
-          - @tournament.runner_counts.each do |id, count|
-            tr
-              td= render id
-              td= count
+= render 'player_counts'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     get :save_json, on: :member
     post :cut, on: :member
     get :qr, on: :member
+    get :registration, on: :member
     get :shortlink, on: :collection
     get :not_found, on: :collection
     get :my, on: :collection


### PR DESCRIPTION
https://user-images.githubusercontent.com/2737888/163634401-e58ba091-0bca-48da-86e5-ed2fc3188480.mov

## List of Changes
### ✏️ Edit Button
After a user has registered for a tournament, they'll see a pencil icon. Clicking this allows them to edit their registration information. If a TO turns off the self-registration setting for a tournament setting, users will still see their registration information but not be able to edit it.

<img width="573" alt="image" src="https://user-images.githubusercontent.com/2737888/163624960-0a111510-0fed-4e32-bb2e-506f0258328a.png">

### Edit Form
This is a new view, despite it intentionally looking very similar. This allows the app to perform an authorization check, in additional to the `POST /tournament/:tId/players/:pId/` authorization, in case users have a stale UI. 

When editing, only TOs will be able to add/remove a first-round bye. I'd love to make the ID selection better, but that'll be it's own effort. 

<img width="573" alt="image" src="https://user-images.githubusercontent.com/2737888/163624980-a3cc2bf0-c61a-40ab-bf35-2d945b135ca4.png">

## Test Plan
* As a TO, create a tournament with the self-registration setting turned on.
* Register yourself for the tournament, give yourself a first-round bye.
* Log out, and log in as a different user. Navigate to the tournament
* Register for the tournament. Verify you cannot set a first-round bye.
* Click the pencil icon. Change your ID. 
* Click save. Verify you see your changes.
* Log out, and log in as the TO.
* Turn off the self-registration setting for the tournament.
* On the tournament tab, verify you can still edit your registration information as the TO.
* Log out, and log back in as the non-TO player.
* Verify you don't see a pencil icon in the "My Registration Information" card.
