### PR TITLE
Create option to cut to top 3

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -115,7 +115,7 @@ class TournamentsController < ApplicationController
     authorize @tournament
 
     number = params[:number].to_i
-    return redirect_to standings_tournament_players_path(@tournament) unless [4,8,16].include? number
+    return redirect_to standings_tournament_players_path(@tournament) unless [3,4,8,16].include? number
 
     @tournament.cut_to!(:double_elim, number)
 

--- a/app/services/bracket/factory.rb
+++ b/app/services/bracket/factory.rb
@@ -1,7 +1,7 @@
 module Bracket
   class Factory
     def self.bracket_for(num_players)
-      raise "bracket size not supported" unless [4,8,16].include? num_players
+      raise "bracket size not supported" unless [3,4,8,16].include? num_players
 
       "Bracket::Top#{num_players}".constantize
     end

--- a/app/services/bracket/top3.rb
+++ b/app/services/bracket/top3.rb
@@ -1,0 +1,13 @@
+module Bracket
+    class Top3 < Base
+      game 1, seed(2), seed(3), round: 1
+
+      game 2, seed(1), winner(1), round: 2
+  
+      STANDINGS = [
+        winner(2),
+        loser(2),
+        loser(1)
+      ]
+    end
+  end

--- a/app/views/rounds/index.html.slim
+++ b/app/views/rounds/index.html.slim
@@ -36,6 +36,9 @@
           | All rounds must be flagged complete before you can add a new round
       - unless @tournament.stages.last.double_elim?
         p
+          => link_to cut_tournament_path(@tournament, number: 3), method: :post, class: 'btn btn-success' do
+            => fa_icon 'scissors'
+            | Cut to Top 3
           => link_to cut_tournament_path(@tournament, number: 4), method: :post, class: 'btn btn-success' do
             => fa_icon 'scissors'
             | Cut to Top 4

--- a/app/views/tournaments/edit.html.slim
+++ b/app/views/tournaments/edit.html.slim
@@ -16,6 +16,9 @@
     p= link_to save_json_tournament_path(@tournament), class: 'btn btn-success', target: '_blank' do |f|
       => fa_icon 'arrow-circle-down'
       | Download as JSON
+    p= button_to cut_tournament_path(@tournament, number: 3), method: :post, class: 'btn btn-success' do
+      => fa_icon 'scissors'
+      | Cut to Top 3
     p= button_to cut_tournament_path(@tournament, number: 4), method: :post, class: 'btn btn-success' do
       => fa_icon 'scissors'
       | Cut to Top 4

--- a/spec/services/bracket/top3_spec.rb
+++ b/spec/services/bracket/top3_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe Bracket::Top3 do
+    let(:tournament) { create(:tournament) }
+    let(:stage) { tournament.stages.create(format: :double_elim) }
+    let(:bracket) { described_class.new(stage) }
+    %w(alpha bravo charlie delta).each do |name|
+      let!(name) { create(:player, tournament: tournament, name: name) }
+    end
+  
+    before do
+      create(:registration, player: alpha, stage: stage, seed: 1)
+      create(:registration, player: bravo, stage: stage, seed: 2)
+      create(:registration, player: charlie, stage: stage, seed: 3)
+      create(:registration, player: delta, stage: stage, seed: 4)
+    end
+  
+    describe '#pair' do
+      context 'round 1' do
+        let(:pair) { bracket.pair(1) }
+  
+        it 'returns correct pairings' do
+          expect(pair).to match_array([
+            { table_number: 1, player1: bravo, player2: charlie },
+          ])
+        end
+      end
+  
+      context 'round 2' do
+        let(:pair) { bracket.pair(2) }
+  
+        before do
+          r1 = create(:round, stage: stage, completed: true)
+          report r1, 1, bravo, 3, charlie, 0
+        end
+  
+        it 'returns correct pairings' do
+          expect(pair).to match_array([
+            { table_number: 2, player1: alpha, player2: bravo },
+          ])
+        end
+      end
+    end
+  
+    describe '#standings' do
+      context 'complete bracket' do
+        before do
+          r1 = create(:round, stage: stage, completed: true)
+          report r1, 1, bravo, 3, charlie, 0
+  
+          r2 = create(:round, stage: stage, completed: true)
+          report r2, 2, alpha, 3, bravo, 0
+        end
+  
+        it 'returns correct standings' do
+          expect(bracket.standings.map(&:player)).to eq(
+            [alpha, bravo, charlie]
+          )
+        end
+      end
+  
+      context 'finals still to play' do
+        before do
+          r1 = create(:round, stage: stage, completed: true)
+          report r1, 1, bravo, 3, charlie, 0
+  
+        end
+  
+        it 'returns fixed finishes' do
+          expect(bracket.standings.map(&:player)).to eq(
+            [nil, nil, charlie]
+          )
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This is to fix #67 

This is my first time contributing to this repo and my first time writing Ruby/Rails, so please forgive any obvious mistakes.

I wanted to pick up a feature that was fairly straight-forward. Though this issue does have a few interesting considerations...

Firstly, the Cut to Top X buttons are getting a little busy now, though given that it is hardcoded for each number it would be difficult to implement it to cut to any arbitrary number.
![image](https://user-images.githubusercontent.com/11884841/198368745-331bf8c8-1464-4e2f-8572-2d475f551c76.png)

Secondly, the Top 3 bracket I've made has been put under "Double Elimination" options, though it isn't double elim, I wasn't really sure how to get around that issue as it seems like double elim is the only strategy for the cut.

Anyway, look forward to feedback and hope this PR is useful.