### PR TITLE
Round timer improvements

### DIFF
--- a/app/assets/javascripts/timer.js.coffee
+++ b/app/assets/javascripts/timer.js.coffee
@@ -33,9 +33,11 @@ $(document).on 'turbolinks:load', ->
 
     if roundTimer.paused
       setTimeRemaining(roundTimer.remaining_seconds * 1000)
-    else
+    else if roundTimer.started
       finishTime = new Date(roundTimer.finish_time)
       renderTimeRemaining = () ->
         setTimeRemaining(finishTime.getTime() - new Date().getTime())
       renderTimeRemaining()
       setInterval(renderTimeRemaining, 100)
+    else
+      $("#round_time_remaining").html(timeRemainingString(roundTimer.length_minutes * 60000))

--- a/app/services/round_timer.rb
+++ b/app/services/round_timer.rb
@@ -42,6 +42,10 @@ class RoundTimer
     end
   end
 
+  def header
+    "Remaining in #{@round.stage.format.humanize(capitalize: false)} round #{@round.number}#{paused? ? ' (paused)' : ''}:"
+  end
+
   private
 
   RunningState = Struct.new(:paused, :finish_time)

--- a/app/services/round_timer.rb
+++ b/app/services/round_timer.rb
@@ -34,11 +34,17 @@ class RoundTimer
     end
   end
 
+  def started?
+    !round_timer_activations.last.nil?
+  end
+
   def state
     if paused?
-      PausedState.new(true, remaining_seconds_after_unpause)
+      PausedState.new(true, true, remaining_seconds_after_unpause)
+    elsif started?
+      RunningState.new(true, false, finish_time)
     else
-      RunningState.new(false, finish_time)
+      NotStartedState.new(false, false, length_minutes)
     end
   end
 
@@ -48,8 +54,9 @@ class RoundTimer
 
   private
 
-  RunningState = Struct.new(:paused, :finish_time)
-  PausedState = Struct.new(:paused, :remaining_seconds)
+  RunningState = Struct.new(:started, :paused, :finish_time)
+  PausedState = Struct.new(:started, :paused, :remaining_seconds)
+  NotStartedState = Struct.new(:started, :paused, :length_minutes)
   attr_reader :round
   delegate :round_timer_activations, :completed?, :length_minutes, to: :round
 

--- a/app/views/layouts/fullscreen.html.slim
+++ b/app/views/layouts/fullscreen.html.slim
@@ -8,6 +8,4 @@ html
     = favicon_link_tag 'favicon.ico'
 
   body.m-0.p-0
-    = link_to :back, style:'cursor:default'
-      .vh-100
-        = yield
+    = yield

--- a/app/views/rounds/_round_timer.html.slim
+++ b/app/views/rounds/_round_timer.html.slim
@@ -1,10 +1,8 @@
 - if round&.timer&.show?
   .alert.alert-primary.mb-0
     => fa_icon 'clock-o'
-    | Remaining in round #{round.number}:&nbsp;
+    | #{round.timer.header}&nbsp;
     span#round_time_remaining
       | 00:00
-    - if round.timer.paused?
-      |  (paused)
   javascript:
     roundTimer = #{raw round.timer.state.to_json};

--- a/app/views/rounds/_round_timer.html.slim
+++ b/app/views/rounds/_round_timer.html.slim
@@ -2,7 +2,8 @@
   .alert.alert-primary.mb-0
     => fa_icon 'clock-o'
     | #{round.timer.header}&nbsp;
-    span#round_time_remaining
+    / Width is fixed to avoid numbers popping around on Mac as the font has numbers of different widths
+    span#round_time_remaining.text-left style='width: 2.6rem; display: inline-block'
       | 00:00
   javascript:
     roundTimer = #{raw round.timer.state.to_json};

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -1,4 +1,5 @@
 
+/ Sizes have been set relative to viewport width (vw) to ensure fullscreen scaling
 .container-fluid
   .fixed-top
     .float-right.text-center.align-middle style='margin: 1vw; font-size: 2vw; line-height: 1'

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -6,7 +6,7 @@
         i.fa.fa-times.text-dark
   .row.vh-100.align-items-center.justify-content-center.text-center
     .col.col-auto style='line-height: 1.1'
-      p style='font-size: 5vw'
+      p style='font-size: 5vw; margin-bottom: 1vw'
         | #{@timer.header}
       .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4.5vw'
         => fa_icon 'clock-o'

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -3,10 +3,7 @@
   .row.vh-100.align-items-center.justify-content-center.text-center
     .col.col-auto style='line-height: 1.1'
       p.text-dark style='font-size: 5vw'
-        | Remaining in round #{@round.number}
-        - if @timer.paused?
-          |  (paused)
-        | :
+        | #{@timer.header}
       .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; width: 90vw'
         => fa_icon 'clock-o'
         - if @timer.show?

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -1,9 +1,9 @@
 
 .container-fluid
   .fixed-top
-    .float-right style="margin: 1vw"
+    .float-right.text-center.align-middle style='margin: 1vw; font-size: 2vw; line-height: 1'
       = link_to :back
-        i.fa.fa-times.text-dark style='font-size: 2vw'
+        i.fa.fa-times.text-dark
   .row.vh-100.align-items-center.justify-content-center.text-center
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw'

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -8,7 +8,7 @@
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw'
         | #{@timer.header}
-      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding-left: 4vw'
+      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4.5vw'
         => fa_icon 'clock-o'
         span#round_time_remaining
           | 00:00

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -1,8 +1,13 @@
 
 .container-fluid
-  .row.vh-100.align-items-center.justify-content-center
-    .col.col-auto
-      .alert.alert-primary.mb-0 style='font-size: 22vw; padding: 0 3vw; border-radius: 2vw; line-height: 1.2'
+  .row.vh-100.align-items-center.justify-content-center.text-center
+    .col.col-auto style='line-height: 1.1'
+      p.text-dark style='font-size: 5vw'
+        | Remaining in round #{@round.number}
+        - if @timer.paused?
+          |  (paused)
+        | :
+      .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; width: 90vw'
         => fa_icon 'clock-o'
         - if @timer.show?
           span#round_time_remaining
@@ -10,4 +15,4 @@
           javascript:
             roundTimer = #{raw @timer.state.to_json};
         - else
-          | #{ @round.length_minutes }:00
+          | #{@round.length_minutes}:00

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -8,7 +8,7 @@
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw; margin-bottom: 1vw'
         | #{@timer.header}
-      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4.3vw'
+      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4vw'
         => fa_icon 'clock-o'
         span#round_time_remaining
           | 00:00

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -6,10 +6,7 @@
         | #{@timer.header}
       .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; width: 90vw'
         => fa_icon 'clock-o'
-        - if @timer.show?
-          span#round_time_remaining
-            | 00:00
-          javascript:
-            roundTimer = #{raw @timer.state.to_json};
-        - else
-          | #{@round.length_minutes}:00
+        span#round_time_remaining
+          | 00:00
+        javascript:
+          roundTimer = #{raw @timer.state.to_json};

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -8,7 +8,7 @@
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw'
         | #{@timer.header}
-      .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; width: 90vw'
+      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding-left: 4vw'
         => fa_icon 'clock-o'
         span#round_time_remaining
           | 00:00

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -10,7 +10,7 @@
         | #{@timer.header}
       .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; padding: 0.5vw 4vw'
         => fa_icon 'clock-o'
-        span#round_time_remaining style='width: 55vw; display: inline-block'
+        span#round_time_remaining.text-left style='width: 55vw; display: inline-block'
           | 00:00
         javascript:
           roundTimer = #{raw @timer.state.to_json};

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -8,7 +8,7 @@
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw; margin-bottom: 1vw'
         | #{@timer.header}
-      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4.5vw'
+      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4.3vw'
         => fa_icon 'clock-o'
         span#round_time_remaining
           | 00:00

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -2,7 +2,7 @@
 .container-fluid
   .fixed-top
     .float-right.text-center.align-middle style='margin: 1vw; font-size: 2vw; line-height: 1'
-      = link_to :back
+      a href='javascript:history.back()'
         i.fa.fa-times.text-dark
   .row.vh-100.align-items-center.justify-content-center.text-center
     .col.col-auto style='line-height: 1.1'

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -10,6 +10,7 @@
         | #{@timer.header}
       .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; padding: 0.5vw 4vw'
         => fa_icon 'clock-o'
+        / Width is fixed to avoid numbers popping around on Mac as the font has numbers of different widths
         span#round_time_remaining.text-left style='width: 55vw; display: inline-block'
           | 00:00
         javascript:

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -1,8 +1,12 @@
 
 .container-fluid
+  .fixed-top
+    .float-right style="margin: 1vw"
+      = link_to :back
+        i.fa.fa-times.text-dark style='font-size: 2vw'
   .row.vh-100.align-items-center.justify-content-center.text-center
     .col.col-auto style='line-height: 1.1'
-      p.text-dark style='font-size: 5vw'
+      p style='font-size: 5vw'
         | #{@timer.header}
       .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; width: 90vw'
         => fa_icon 'clock-o'

--- a/app/views/tournaments/timer.html.slim
+++ b/app/views/tournaments/timer.html.slim
@@ -8,9 +8,9 @@
     .col.col-auto style='line-height: 1.1'
       p style='font-size: 5vw; margin-bottom: 1vw'
         | #{@timer.header}
-      .alert.alert-primary.mb-0.text-left style='font-size: 22vw; border-radius: 2vw; width: 90vw; padding: 0.5vw 4vw'
+      .alert.alert-primary.mb-0 style='font-size: 22vw; border-radius: 2vw; padding: 0.5vw 4vw'
         => fa_icon 'clock-o'
-        span#round_time_remaining
+        span#round_time_remaining style='width: 55vw; display: inline-block'
           | 00:00
         javascript:
           roundTimer = #{raw @timer.state.to_json};

--- a/spec/feature/rounds/round_timer_spec.rb
+++ b/spec/feature/rounds/round_timer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'round timer' do
   end
 
   def timer_display_message
-    "Remaining in round 1:"
+    "Remaining in swiss round 1"
   end
 
 end


### PR DESCRIPTION
Add type of round to timer message (swiss/double elim).
Add message to fullscreen timer.
Exit fullscreen timer with a close button rather than by clicking anywhere.
Distinguish state of round not started yet for fullscreen timer view.