### PR TITLE
Public decklists in cut

### DIFF
--- a/app/assets/javascripts/deck_display.js.coffee.erb
+++ b/app/assets/javascripts/deck_display.js.coffee.erb
@@ -5,40 +5,42 @@ $(document).on 'turbolinks:load', ->
   if document.getElementById('display_decks')? || document.getElementById('display_pairing_decks')?
 
     window.renderDecksDisplay = (decks) =>
-      normaliseCardTables(decks)
       $('#display_decks').empty().append(
-        renderDeck(decks.corp),
-        renderDeck(decks.runner))
+        renderDecksDisplayLeftRight({left: decks.corp, right: decks.runner}))
       any_changes = decks.corp.change_type != 'none' || decks.runner.change_type != 'none'
       $('#deck_changes_not_submitted_warning').toggleClass('d-none', !any_changes)
 
+    renderDecksDisplayLeftRight = (decks) =>
+      normaliseCardTables(decks)
+      [
+        renderDeck(decks.left),
+        renderDeck(decks.right)
+      ]
+
     normaliseCardTables = (decks) =>
-      decks.corp.pad_cards = 0
-      decks.runner.pad_cards = 0
-      if decks.corp.change_type != decks.runner.change_type
+      decks.left.pad_cards = 0
+      decks.right.pad_cards = 0
+      if decks.left.change_type != decks.right.change_type
         return decks
-      if decks.corp.change_type != 'change_cards'
-        max_cards = Math.max(decks.runner.after.cards.length, decks.corp.after.cards.length)
-        decks.corp.pad_cards = max_cards - decks.corp.after.cards.length
-        decks.runner.pad_cards = max_cards - decks.runner.after.cards.length
+      if decks.left.change_type != 'change_cards'
+        max_cards = Math.max(decks.right.after.cards.length, decks.left.after.cards.length)
+        decks.left.pad_cards = max_cards - decks.left.after.cards.length
+        decks.right.pad_cards = max_cards - decks.right.after.cards.length
       decks
 
-    renderPairingDeck = (decks) =>
-      renderDeck(decks, true)
-
-    renderDeck = (decks, viewOnly) =>
+    renderDeck = (decks) =>
       $container = $('<div/>', {class: 'col-md-6'})
       if decks.before.unset && decks.after.unset
         return $container
       deck = decks.after
       $container.append(
-        deckSummaryTable(decks, viewOnly),
+        deckSummaryTable(decks),
         deckDiffTable(decks.diff),
         identityTable(deck),
         cardsTable(decks),
         totalsTable(deck))
 
-    deckSummaryTable = (decks, viewOnly) =>
+    deckSummaryTable = (decks) =>
       return $('<table/>', {
         class: 'table table-bordered table-striped'
       }).append(
@@ -46,7 +48,7 @@ $(document).on 'turbolinks:load', ->
           $('<tr/>').append(
             $('<th/>', {class: 'text-center deck-name-header', text: decks.description}))),
         $('<tbody/>')
-          .append(deckNameRow(decks.after, viewOnly))
+          .append(deckNameRow(decks.after, decks.viewOnly))
           .append(deckChangesRow(decks)))
 
     deckNameRow = (deck, viewOnly) =>
@@ -292,6 +294,9 @@ $(document).on 'turbolinks:load', ->
         console.log(e)
 
     if document.getElementById('display_pairing_decks')?
-      $('#display_pairing_decks').append(
-        renderPairingDeck(readPlayer1DeckFromInputs()),
-        renderPairingDeck(readPlayer2DeckFromInputs()))
+      try
+        decks = readPairingDecksFromInputs()
+        $('#display_pairing_decks').append(
+          renderDecksDisplayLeftRight({left: decks.player1, right: decks.player2}))
+      catch e
+        console.log(e)

--- a/app/assets/javascripts/deck_display.js.coffee.erb
+++ b/app/assets/javascripts/deck_display.js.coffee.erb
@@ -2,7 +2,7 @@
 #= require nrdb_cards
 
 $(document).on 'turbolinks:load', ->
-  if document.getElementById('display_decks')? || document.getElementById('display_opponent_deck')?
+  if document.getElementById('display_decks')? || document.getElementById('display_pairing_decks')?
 
     window.renderDecksDisplay = (decks) =>
       normaliseCardTables(decks)
@@ -23,22 +23,22 @@ $(document).on 'turbolinks:load', ->
         decks.runner.pad_cards = max_cards - decks.runner.after.cards.length
       decks
 
-    renderOpponentDeck = (decks) =>
+    renderPairingDeck = (decks) =>
       renderDeck(decks, true)
 
-    renderDeck = (decks, opponent) =>
+    renderDeck = (decks, viewOnly) =>
       $container = $('<div/>', {class: 'col-md-6'})
       if decks.before.unset && decks.after.unset
         return $container
       deck = decks.after
       $container.append(
-        deckSummaryTable(decks, opponent),
+        deckSummaryTable(decks, viewOnly),
         deckDiffTable(decks.diff),
         identityTable(deck),
         cardsTable(decks),
         totalsTable(deck))
 
-    deckSummaryTable = (decks, opponent) =>
+    deckSummaryTable = (decks, viewOnly) =>
       return $('<table/>', {
         class: 'table table-bordered table-striped'
       }).append(
@@ -46,20 +46,20 @@ $(document).on 'turbolinks:load', ->
           $('<tr/>').append(
             $('<th/>', {class: 'text-center deck-name-header', text: decks.description}))),
         $('<tbody/>')
-          .append(deckNameRow(decks.after, opponent))
+          .append(deckNameRow(decks.after, viewOnly))
           .append(deckChangesRow(decks)))
 
-    deckNameRow = (deck, opponent) =>
+    deckNameRow = (deck, viewOnly) =>
       if deck.details.name
         $('<tr/>').append($('<td/>')
-          .append(deckNameButtons(deck, opponent))
+          .append(deckNameButtons(deck, viewOnly))
           .append(document.createTextNode(deck.details.name)))
       else
         $('<tr/>').append($('<td/>')
           .append('None selected'))
 
-    deckNameButtons = (deck, opponent) =>
-      if opponent
+    deckNameButtons = (deck, viewOnly) =>
+      if viewOnly
         []
       else if deck.details.mine
         $('<a/>', {
@@ -291,6 +291,7 @@ $(document).on 'turbolinks:load', ->
       catch e
         console.log(e)
 
-    if document.getElementById('display_opponent_deck')?
-      $('#display_opponent_deck').append(
-        renderOpponentDeck(readOpponentDeckFromInputs()))
+    if document.getElementById('display_pairing_decks')?
+      $('#display_pairing_decks').append(
+        renderPairingDeck(readPlayer1DeckFromInputs()),
+        renderPairingDeck(readPlayer2DeckFromInputs()))

--- a/app/assets/javascripts/deck_model.js.coffee
+++ b/app/assets/javascripts/deck_model.js.coffee
@@ -1,5 +1,5 @@
 $(document).on 'turbolinks:load', ->
-  if document.getElementById('player_corp_deck')? || document.getElementById('opponent_deck')?
+  if document.getElementById('player_corp_deck')? || document.getElementById('display_pairing_decks')?
     window.readDecksFromInputs = () =>
       {
         corp: readSideDecks(
@@ -12,8 +12,11 @@ $(document).on 'turbolinks:load', ->
           $('#player_runner_deck'))
       }
 
-    window.readOpponentDeckFromInputs = () =>
-      readSideDecks($('#opponent_name').val(), [], $('#opponent_deck'))
+    window.readPlayer1DeckFromInputs = () =>
+      readSideDecks($('#player1_name').val(), [], $('#player1_deck'))
+
+    window.readPlayer2DeckFromInputs = () =>
+      readSideDecks($('#player2_name').val(), [], $('#player2_deck'))
 
     readSideDecks = (description, $beforeInput, $afterInput) =>
       after = readDeck($afterInput)

--- a/app/assets/javascripts/deck_model.js.coffee
+++ b/app/assets/javascripts/deck_model.js.coffee
@@ -12,11 +12,15 @@ $(document).on 'turbolinks:load', ->
           $('#player_runner_deck'))
       }
 
-    window.readPlayer1DeckFromInputs = () =>
-      readSideDecks($('#player1_name').val(), [], $('#player1_deck'))
+    window.readPairingDecksFromInputs = () =>
+      {
+        player1: markPairingDeck(readSideDecks($('#player1_name').val(), [], $('#player1_deck'))),
+        player2: markPairingDeck(readSideDecks($('#player2_name').val(), [], $('#player2_deck')))
+      }
 
-    window.readPlayer2DeckFromInputs = () =>
-      readSideDecks($('#player2_name').val(), [], $('#player2_deck'))
+    markPairingDeck = (decks) =>
+      decks.viewOnly = true
+      decks
 
     readSideDecks = (description, $beforeInput, $afterInput) =>
       after = readDeck($afterInput)

--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -9,12 +9,16 @@ class PairingsController < ApplicationController
       pairings << {
         table_number: p.table_number,
         player1_name: p.player1.name_with_pronouns,
-        player2_name: p.player2.name_with_pronouns
+        player2_name: p.player2.name_with_pronouns,
+        view_decks: p.cut_decks_visible_to(current_user),
+        pairing: p
       }
       pairings << {
         table_number: p.table_number,
         player1_name: p.player2.name_with_pronouns,
-        player2_name: p.player1.name_with_pronouns
+        player2_name: p.player1.name_with_pronouns,
+        view_decks: p.cut_decks_visible_to(current_user),
+        pairing: p
       }
     end.sort_by { |p| p[:player1_name] }
   end

--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -53,20 +53,9 @@ class PairingsController < ApplicationController
     end
   end
 
-  def view_opponent_deck
+  def view_decks
     authorize @tournament, :show?
-    unless @tournament.open_list_cut? && pairing.stage.double_elim?
-      return
-    end
-    @opponent = pairing.user_opponent(current_user)
-    if @opponent
-      @opponent_side = pairing.side_for @opponent
-      if @opponent_side == :corp
-        @deck = @opponent.corp_deck
-      else
-        @deck = @opponent.runner_deck
-      end
-    end
+    authorize pairing
   end
 
   private

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -176,7 +176,7 @@ class TournamentsController < ApplicationController
 
   def tournament_params
     params.require(:tournament).permit(:name, :date, :private, :stream_url, :manual_seed,
-                                       :self_registration, :nrdb_deck_registration, :open_list_cut)
+                                       :self_registration, :nrdb_deck_registration, :open_list_cut, :public_list_cut)
   end
 
   def set_tournament_view_data

--- a/app/models/pairing.rb
+++ b/app/models/pairing.rb
@@ -76,20 +76,37 @@ class Pairing < ApplicationRecord
     player1_is_corp? ? :runner : :corp
   end
 
+  def cut_decks_visible_to(user)
+    unless stage.double_elim? && !side.nil?
+      return false
+    end
+    if tournament.open_list_cut? && (player1 == user || player2 == user)
+      true
+    else
+      tournament.public_list_cut?
+    end
+  end
+
+  def player1_deck
+    if side.nil?
+      nil
+    else
+      player1_is_corp? ? player1.corp_deck : player1.runner_deck
+    end
+  end
+
+  def player2_deck
+    if side.nil?
+      nil
+    else
+      player1_is_runner? ? player2.corp_deck : player2.runner_deck
+    end
+  end
+
   def side_for(player)
     return unless players.include? player
 
     player1 == player ? player1_side : player2_side
-  end
-
-  def user_opponent(user)
-    if player1.user_id == user.id
-      player2
-    elsif player2.user_id == user.id
-      player1
-    else
-      nil
-    end
   end
 
   private
@@ -102,8 +119,7 @@ class Pairing < ApplicationRecord
   end
 
   def combine_separate_side_scores
-    return unless
-      (score1_corp.present? && score1_corp > 0) ||
+    return unless (score1_corp.present? && score1_corp > 0) ||
       (score1_runner.present? && score1_runner > 0) ||
       (score2_corp.present? && score2_corp > 0) ||
       (score2_runner.present? && score2_runner > 0)
@@ -113,8 +129,7 @@ class Pairing < ApplicationRecord
   end
 
   def ensure_custom_scores_complete
-    return unless
-      score1.present? || score2.present?
+    return unless score1.present? || score2.present?
 
     self.score1 = score1 || 0
     self.score2 = score2 || 0

--- a/app/policies/pairing_policy.rb
+++ b/app/policies/pairing_policy.rb
@@ -1,0 +1,15 @@
+class PairingPolicy < ApplicationPolicy
+  def view_decks?
+    if record.tournament.user == user
+      return true
+    end
+    unless record.stage.double_elim?
+      return false
+    end
+    if @tournament.open_list_cut?
+      user == record.player1.user || user == record.player2.user
+    else
+      @tournament.public_list_cut?
+    end
+  end
+end

--- a/app/policies/pairing_policy.rb
+++ b/app/policies/pairing_policy.rb
@@ -1,15 +1,5 @@
 class PairingPolicy < ApplicationPolicy
   def view_decks?
-    if record.tournament.user == user
-      return true
-    end
-    unless record.stage.double_elim?
-      return false
-    end
-    if @tournament.open_list_cut?
-      user == record.player1.user || user == record.player2.user
-    else
-      @tournament.public_list_cut?
-    end
+    record.cut_decks_visible_to(user)
   end
 end

--- a/app/views/pairings/index.html.slim
+++ b/app/views/pairings/index.html.slim
@@ -14,6 +14,11 @@
     tbody
       - @pairings.each do |p|
         tr
-          td= p[:table_number]
+          td
+            | #{p[:table_number]}
+            - if p[:view_decks]
+              =< link_to view_decks_tournament_round_pairing_path(@tournament, @round, p[:pairing]), class: 'ml-2' do
+                => fa_icon 'eye'
+                | View decks
           td= p[:player1_name]
           td= p[:player2_name]

--- a/app/views/pairings/view_decks.html.slim
+++ b/app/views/pairings/view_decks.html.slim
@@ -3,6 +3,8 @@ input#player2_name type='hidden' value='#{@pairing.player2&.name}'
 input#player1_deck type='hidden' value='#{@pairing.player1_deck&.as_view(current_user).to_json}'
 input#player2_deck type='hidden' value='#{@pairing.player2_deck&.as_view(current_user).to_json}'
 .container
-  .col
-    h4 Round
+  .row.mb-2
+    .col
+      h4 #{@pairing.stage.format.titleize}
+      h5 Round #{@pairing.round.number} table #{@pairing.table_number}
   .row#display_pairing_decks

--- a/app/views/pairings/view_decks.html.slim
+++ b/app/views/pairings/view_decks.html.slim
@@ -1,0 +1,8 @@
+input#player1_name type='hidden' value='#{@pairing.player1&.name}'
+input#player2_name type='hidden' value='#{@pairing.player2&.name}'
+input#player1_deck type='hidden' value='#{@pairing.player1_deck&.as_view(current_user).to_json}'
+input#player2_deck type='hidden' value='#{@pairing.player2_deck&.as_view(current_user).to_json}'
+.container
+  .col
+    h4 Round
+  .row#display_pairing_decks

--- a/app/views/pairings/view_decks.html.slim
+++ b/app/views/pairings/view_decks.html.slim
@@ -1,3 +1,8 @@
+.col-12
+  p.dontprint= link_to tournament_rounds_path(@tournament), class: 'btn btn-primary' do
+    => fa_icon 'arrow-left'
+    | Back to pairings
+
 input#player1_name type='hidden' value='#{@pairing.player1&.name}'
 input#player2_name type='hidden' value='#{@pairing.player2&.name}'
 input#player1_deck type='hidden' value='#{@pairing.player1_deck&.as_view(current_user).to_json}'

--- a/app/views/pairings/view_opponent_deck.html.slim
+++ b/app/views/pairings/view_opponent_deck.html.slim
@@ -1,4 +1,0 @@
-input#opponent_name type='hidden' value='#{@opponent&.name}'
-input#opponent_deck type='hidden' value='#{@deck&.as_view(current_user).to_json}'
-.container
-  .row.justify-content-center#display_opponent_deck

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -2,13 +2,13 @@
 - round.pairings.each do |pairing|
   .row.m-1.round_pairing.align-items-center class="table_#{pairing.table_number} #{'reported' if pairing.reported? && current_user == @tournament.user}"
     .col-sm-2 Table #{pairing.table_number}
+    - if pairing.cut_decks_visible_to(current_user)
+      =< link_to view_decks_tournament_round_pairing_path(@tournament, round, pairing), class: 'btn btn-sm btn-info' do
+        => fa_icon 'eye'
+        | View decks
     .col-sm.left_player_name
       = @players[pairing.player1_id].name_with_pronouns
       =< render 'player_side', pairing: pairing, player: @players[pairing.player1_id], single_sided: single_sided
-      - if round.stage.double_elim? && @tournament.open_list_cut? && @players[pairing.player2_id].user_id == current_user.id
-        =< link_to view_opponent_deck_tournament_round_pairing_path(@tournament, round, pairing), class: 'btn btn-sm btn-info' do
-          => fa_icon 'eye'
-          | View deck
       - if @players[pairing.player1_id].id
         .ids
           = render @players[pairing.player1_id].corp_identity_object
@@ -51,10 +51,6 @@
     .col-sm.right_player_name
       = @players[pairing.player2_id].name_with_pronouns
       =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided
-      - if @tournament.open_list_cut? && @players[pairing.player1_id].user_id == current_user.id
-        =< link_to view_opponent_deck_tournament_round_pairing_path(@tournament, round, pairing), class: 'btn btn-sm btn-info' do
-          => fa_icon 'eye'
-          | View deck
       - if @players[pairing.player2_id].id
         .ids
           = render @players[pairing.player2_id].corp_identity_object

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -3,7 +3,7 @@
   .row.m-1.round_pairing.align-items-center class="table_#{pairing.table_number} #{'reported' if pairing.reported? && current_user == @tournament.user}"
     .col-sm-2 Table #{pairing.table_number}
     - if pairing.cut_decks_visible_to(current_user)
-      =< link_to view_decks_tournament_round_pairing_path(@tournament, round, pairing), class: 'btn btn-sm btn-info' do
+      =< link_to view_decks_tournament_round_pairing_path(@tournament, round, pairing) do
         => fa_icon 'eye'
         | View decks
     .col-sm.left_player_name

--- a/app/views/tournaments/_form.html.slim
+++ b/app/views/tournaments/_form.html.slim
@@ -12,6 +12,8 @@
 - if Flipper.enabled? :open_list_cut
   .form-group
     = f.input :open_list_cut, as: :boolean, inline_label: 'Open lists in cut: Display uploaded decks to opponent in cut'
+  .form-group
+    = f.input :public_list_cut, as: :boolean, inline_label: 'Public lists in cut: Decks of all players in cut will be public'
 .form-group
   = f.input :private, as: :boolean, inline_label: 'Private: Only I will be able to view this tournament'
 .form-group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       resources :pairings, only: [:index, :create, :destroy] do
         post :report, on: :member
         get :match_slips, on: :collection
-        get :view_opponent_deck, on: :member
+        get :view_decks, on: :member
       end
       patch :repair, on: :member
       patch :complete, on: :member

--- a/db/migrate/20230819221525_add_public_list_cut_flag.rb
+++ b/db/migrate/20230819221525_add_public_list_cut_flag.rb
@@ -1,0 +1,5 @@
+class AddPublicListCutFlag < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tournaments, :public_list_cut, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_19_205733) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_19_221525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -208,6 +208,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_19_205733) do
     t.boolean "any_player_unlocked", default: true
     t.boolean "open_list_cut", default: false
     t.boolean "registration_closed"
+    t.boolean "public_list_cut", default: false
     t.index ["user_id"], name: "index_tournaments_on_user_id"
   end
 


### PR DESCRIPTION
Resolves #187

Still to do:
- View decks links in cut standings
- Replace tournament settings flag with a button to make cut decks public
  - with confirmation
  - on players screen and maybe rounds
- Remove opponent-only open lists