### PR TITLE
Fix deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,4 @@
 /docker-compose*
 /config/database*
 /config/secrets*
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+/data
 *.log
 *.log.*
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = Uglifier.new(harmony: true, :mangle => false, :compress => false)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/deploy/bin/in-droplet/cloud-init
+++ b/deploy/bin/in-droplet/cloud-init
@@ -5,7 +5,9 @@ set -x # Trace commands
 set -o pipefail
 
 # Get Updates
-apt-get -y update && apt-get -y dist-upgrade && apt-get -y autoremove
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+apt-get autoremove
 
 # Ensure git is installed
 apt-get -y install git

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       - "3000"
 
     volumes:
-      - cobra-logs:/var/www/cobra/log
+      - cobra-vite:/var/www/cobra/public/vite
 
   # service configuration for our web server
   web:
@@ -47,6 +47,7 @@ services:
     volumes:
       - cobra-logs:/var/www/cobra/log
       - cobra-assets:/var/www/cobra/public/assets
+      - cobra-vite:/var/www/cobra/public/vite
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
 
@@ -60,4 +61,5 @@ services:
 
 volumes:
     cobra-assets:
+    cobra-vite:
     cobra-logs:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,9 +18,6 @@ services:
     expose:
       - "3000"
 
-    volumes:
-      - cobra-vite:/var/www/cobra/public/vite
-
   # service configuration for our web server
   web:
     restart: unless-stopped

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -28,14 +28,7 @@ services:
     expose:
       - "3000"
 
-    volumes:
-      - cobra-logs:/var/www/cobra/log
-
 networks:
   backend:
   null_signal:
     external: true
-
-volumes:
-  cobra-assets:
-  cobra-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./config/secrets.yml:/var/www/cobra/config/secrets.yml
       - cobra-logs:/var/www/cobra/log
       - cobra-assets:/var/www/cobra/public/assets
+      - cobra-vite:/var/www/cobra/public/vite
       - cobra-tmp:/var/www/cobra/tmp
 
   # service configuration for our database
@@ -45,6 +46,7 @@ services:
 
 volumes:
   cobra-assets:
+  cobra-vite:
   cobra-logs:
   cobra-postgres:
   cobra-tmp:


### PR DESCRIPTION
Fixes for deployment on staging server, and on a prod-like server with Pulumi

- Ignored data folder
  - Docker build was failing on staging
  - Some certbot files had different permissions so they weren't accessible for setting up the Docker context
  - Excluded them from the Docker context entirely
- Configured Uglifier for compatibility with latest version of Rails
- Fixed build of droplet in Pulumi as a dependency was prompting during update
- Mounted a volume for Vite assets so they'll be kept when precompiling assets