### PR TITLE
Deploy nginx separately

### DIFF
--- a/deploy/bin/github-actions-deploy-in-droplet
+++ b/deploy/bin/github-actions-deploy-in-droplet
@@ -17,7 +17,7 @@ touch "$ENV_FILE"
 chmod u=rw,g=,o= "$ENV_FILE"
 {
   echo "RAILS_ENV=production"
-  echo "COMPOSE_FILE=prod"
+  echo "COMPOSE_FILE=staging"
   echo "POSTGRES_PASSWORD=$(pulumi stack output postgres_password --show-secrets)"
   echo "SECRET_KEY_BASE=$(pulumi stack output rails_secret_key_base --show-secrets)"
   echo "COBRA_DOMAIN=$(pulumi stack output cobra_domain)"

--- a/deploy/bin/in-droplet/deploy
+++ b/deploy/bin/in-droplet/deploy
@@ -6,19 +6,31 @@ set -e
 # GIT_BRANCH: branchname
 # See also /bin/deploy from the project root
 source .env
-REPOSITORY=$GIT_REPOSITORY
-BRANCH=$GIT_BRANCH
-GIT_URL="https://github.com/$REPOSITORY.git"
 
-if [[ ! -d cobra ]]; then
-  git clone -b "$BRANCH" "$GIT_URL" cobra
-fi
+update_git() {
+  local GIT_DIR=$1
+  local GIT_URL=$2
+  local BRANCH=$3
+  if [[ ! -d $GIT_DIR ]]; then
+    git clone -b "$BRANCH" "$GIT_URL" "$GIT_DIR"
+  fi
+  pushd "$GIT_DIR"
+  git remote set-url origin "$GIT_URL"
+  git fetch
+  git checkout -B "$BRANCH" --track "origin/$BRANCH" --force
+  popd
+}
+
+update_git nginx https://github.com/Project-NISEI/nsg-infra.git main
+update_git cobra "https://github.com/$GIT_REPOSITORY.git" "$GIT_BRANCH"
+
+pushd nginx
+docker network inspect null_signal >/dev/null 2>&1 || \
+    docker network create --driver bridge null_signal
+docker compose up -d
+popd
 
 pushd cobra
-
-git remote set-url origin "$GIT_URL"
-git fetch
-git checkout -B "$BRANCH" --track "origin/$BRANCH" --force
 
 {
   echo "RAILS_ENV=$RAILS_ENV"

--- a/deploy/bin/in-droplet/deploy
+++ b/deploy/bin/in-droplet/deploy
@@ -11,6 +11,9 @@ update_git() {
   local GIT_DIR=$1
   local GIT_URL=$2
   local BRANCH=$3
+  echo "Updating git repo at $GIT_DIR"
+  echo "URL: $GIT_URL"
+  echo "Branch: $BRANCH"
   if [[ ! -d $GIT_DIR ]]; then
     git clone -b "$BRANCH" "$GIT_URL" "$GIT_DIR"
   fi


### PR DESCRIPTION
Work on using staging setup for production.

Probably needs more work on NGINX config. It's currently in a private repo, so this change doesn't work right now as the droplet can't clone it.

If this works we can get rid of the old prod configuration and rename the staging one to prod.