### PR TITLE
Use javascript:history.back() explicitly in player meeting

### DIFF
--- a/app/views/players/meeting.html.slim
+++ b/app/views/players/meeting.html.slim
@@ -1,5 +1,5 @@
 .col-12
-  p.dontprint= link_to :back, class: 'btn btn-primary' do
+  p.dontprint= link_to 'javascript:history.back()', class: 'btn btn-primary' do
     => fa_icon 'arrow-left'
     | Back to pairings
 


### PR DESCRIPTION
Previously this was sometimes referring back to the tournament registration screen, as that ended up as the referrer even when you went through the pairings screen.