### PR TITLE
Add scripts to create user in Pulumi-deployed droplet

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ some steps for setting that up.
 
 You can deploy a droplet directly with `pulumi up` if you're logged into Pulumi and DigitalOcean, but this will not
 deploy Cobra. You can follow the instructions above for manual deployment on the droplet, or use the automated
-deployment below. You can SSH to the resulting droplet with `deploy/bin/ssh-to-droplet`.
+deployment below.
+
+You can SSH to the resulting droplet with `deploy/bin/ssh-to-droplet`. If you have an SSH key you'd like to use to log
+in, you can create a non-root user on the droplet with `deploy/bin/create-user-with-key`.
 
 If you'd prefer to manage the resulting droplet manually and just use this as a way to create a droplet, you can discard
 the resulting Pulumi stack. It may be easier to hold state locally for this, rather than creating a stack in Pulumi

--- a/deploy/bin/create-user-with-key
+++ b/deploy/bin/create-user-with-key
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 user_name /path/to/id_ed25519.pub"
+    exit 1
+fi
+
+NEW_USERNAME=$1
+PUB_FILE=$2
+
+DEPLOY_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+STACK=$(pulumi stack --show-name)
+DROPLET_IP=$(pulumi stack output droplet_public_ip)
+PRIVATE_KEY_FILE="$DEPLOY_DIR/id_cobra_$STACK"
+KNOWN_HOSTS_FILE="$DEPLOY_DIR/known_hosts_cobra_$STACK"
+CREATE_USER_SCRIPT="$DEPLOY_DIR/bin/in-droplet/create-user-with-key"
+
+touch "$PRIVATE_KEY_FILE"
+chmod u=rw,g=,o= "$PRIVATE_KEY_FILE"
+pulumi stack output private_key_openssh --show-secrets > "$PRIVATE_KEY_FILE"
+echo "Retrieved connection details"
+
+echo "Uploading script"
+scp -i "$PRIVATE_KEY_FILE" -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE" "$CREATE_USER_SCRIPT" "root@$DROPLET_IP:create-user-with-key"
+
+echo "Uploading public key"
+scp -i "$PRIVATE_KEY_FILE" -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE" "$PUB_FILE" "root@$DROPLET_IP:id.pub"
+
+echo "Setting script permissions"
+ssh -i "$PRIVATE_KEY_FILE" -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE" "root@$DROPLET_IP" chmod 700 ./create-user-with-key
+
+echo "Creating user"
+ssh -i "$PRIVATE_KEY_FILE" -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE" "root@$DROPLET_IP" ./create-user-with-key "$NEW_USERNAME" ./id.pub
+
+SSH_EXIT_CODE=$?
+rm "$PRIVATE_KEY_FILE"
+echo "Connect with ssh $NEW_USERNAME@$DROPLET_IP"
+exit $SSH_EXIT_CODE

--- a/deploy/bin/in-droplet/create-user-with-key
+++ b/deploy/bin/in-droplet/create-user-with-key
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 user_name /path/to/id_ed25519.pub"
+    exit 1
+fi
+
+NEW_USERNAME=$1
+PUB_FILE=$2
+
+adduser --disabled-password --gecos "" "$NEW_USERNAME"
+usermod -aG sudo "$NEW_USERNAME"
+
+NEW_HOME=$(eval echo ~"$NEW_USERNAME")
+
+mkdir "$NEW_HOME/.ssh"
+chown "$NEW_USERNAME:$NEW_USERNAME" "$NEW_HOME/.ssh"
+chmod 700 "$NEW_HOME/.ssh"
+cat "$PUB_FILE" > "$NEW_HOME/.ssh/authorized_keys"
+chown "$NEW_USERNAME:$NEW_USERNAME" "$NEW_HOME/.ssh/authorized_keys"
+chmod 600 "$NEW_HOME/.ssh/authorized_keys"


### PR DESCRIPTION
A script to add an SSH key to a droplet deployed via Pulumi, so that you can access it with the same SSH key you use for other droplets. This should make it easier to invoke any further setup for the droplet, particularly as you can then SSH into the old and new droplet with the same SSH key and user in the same script.

**WARNING, this PR is stacked on top of the following PR:**
- https://github.com/Project-NISEI/cobra/pull/295

In order to merge this PR, please change the base branch of the PR to main first. Do not merge until the PR above has been merged.

If this PR is based on main, all the changes from that PR will be included as well if they're not already in main. If the base branch is not changed, the merge will not have any useful effect.

This has been done to pre-integrate the changes from the linked PR, rather than needing to wait for them to be merged.