### PR TITLE
Avoid using compose file env var in bin/init-db-from-docker

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -5,12 +5,12 @@ PROJECT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "../" && pwd)
 pushd "${PROJECT_DIR}"
 
 # Optional environment variable in .env:
-# COMPOSE_FILE: prod, staging, override (for local dev - this is the default)
+# COMPOSE_FILE_TYPE: prod, staging, override (for local dev - this is the default)
 source .env
-COMPOSE_FILE=${COMPOSE_FILE-override}
+COMPOSE_FILE_TYPE=${COMPOSE_FILE_TYPE-override}
 
 compose_for_deploy() {
-  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE.yml" "$@"
+  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE_TYPE.yml" "$@"
 }
 
 compose_for_deploy build app

--- a/bin/deploy
+++ b/bin/deploy
@@ -8,7 +8,7 @@ pushd "${PROJECT_DIR}"
 # RAILS_ENV: develop or production
 # POSTGRES_PASSWORD: should be randomly generated per instance
 # Optional:
-# COMPOSE_FILE: prod, staging, override (for local dev - this is the default)
+# COMPOSE_FILE_TYPE: prod, staging, override (for local dev - this is the default)
 # Required if using production Rails environment:
 # SECRET_KEY_BASE: A 64 bit hex key for rails, should be randomly generated
 # ABR_AUTH
@@ -17,10 +17,10 @@ pushd "${PROJECT_DIR}"
 # Required if using prod or staging compose file:
 # COBRA_DOMAIN
 source .env
-COMPOSE_FILE=${COMPOSE_FILE-override}
+COMPOSE_FILE_TYPE=${COMPOSE_FILE_TYPE-override}
 
 compose_for_deploy() {
-  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE.yml" "$@"
+  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE_TYPE.yml" "$@"
 }
 
 compose_for_deploy up -d db
@@ -32,9 +32,9 @@ bin/init-db app-in-docker
 echo "Precompiling assets..."
 compose_for_deploy run --rm app bundle exec rake assets:precompile --trace
 
-if [ "$COMPOSE_FILE" == "prod" ]; then
+if [ "$COMPOSE_FILE_TYPE" == "prod" ]; then
   compose_for_deploy up -d app --force-recreate
-elif [ "$COMPOSE_FILE" == "staging" ]; then
+elif [ "$COMPOSE_FILE_TYPE" == "staging" ]; then
   compose_for_deploy up -d app --force-recreate
 fi
 

--- a/bin/init-db
+++ b/bin/init-db
@@ -7,7 +7,7 @@ pushd "${PROJECT_DIR}"
 
 source .env
 DB_NAME=cobra
-COMPOSE_FILE=${COMPOSE_FILE-override}
+COMPOSE_FILE_TYPE=${COMPOSE_FILE_TYPE-override}
 
 if [ $# -lt 1 ]; then
   echo "Usage: $0 [app-in-docker|app-in-host]"
@@ -17,7 +17,7 @@ fi
 APP_RUN_TYPE=$1
 
 compose_for_deploy() {
-  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE.yml" "$@"
+  docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE_TYPE.yml" "$@"
 }
 
 run_as_app() {

--- a/bin/init-db-from-docker
+++ b/bin/init-db-from-docker
@@ -5,7 +5,9 @@ THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 PROJECT_DIR=$(cd "$THIS_DIR" && cd "../" && pwd)
 pushd "${PROJECT_DIR}"
-docker compose -f docker-compose.yml build app
+source .env
+COMPOSE_FILE_TYPE=${COMPOSE_FILE_TYPE-override}
+docker compose -f docker-compose.yml -f "docker-compose.$COMPOSE_FILE_TYPE.yml" build app
 popd
 
 $THIS_DIR/init-db app-in-docker

--- a/bin/init-db-from-docker
+++ b/bin/init-db-from-docker
@@ -5,7 +5,7 @@ THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 PROJECT_DIR=$(cd "$THIS_DIR" && cd "../" && pwd)
 pushd "${PROJECT_DIR}"
-docker compose build app
+docker compose -f docker-compose.yml build app
 popd
 
 $THIS_DIR/init-db app-in-docker


### PR DESCRIPTION
Docker Compose now applies any environment variable COMPOSE_FILE as though it was passed with the -f flag:
https://docs.docker.com/reference/cli/docker/compose/#set-up-environment-variables