### PR TITLE
Single Sided Swiss UI Improvements

### DIFF
--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -18,7 +18,18 @@ class PairingsController < ApplicationController
         player2_name: p.player1.name_with_pronouns,
         pairing: p
       }
-    end.sort_by { |p| p[:player1_name] }
+    end.sort_by do |p|
+      # Sort by username for doublesided, but Corp username for Single-Sided Swiss.
+      if p[:pairing].round.stage.format == :single_sided_swiss.to_s
+        if p[:pairing].side == 'player1_is_corp'
+          p[:player1_name].downcase
+        else
+          p[:player2_name].downcase
+        end
+      else
+        p[:player1_name].downcase
+      end
+    end
   end
 
   def create

--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 class PairingsController < ApplicationController
   before_action :set_tournament
   attr_reader :tournament

--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 class PairingsController < ApplicationController
   before_action :set_tournament
   attr_reader :tournament
@@ -9,26 +11,21 @@ class PairingsController < ApplicationController
       pairings << {
         table_number: p.table_number,
         player1_name: p.player1.name_with_pronouns,
+        player1_side: p.side == 'player1_is_corp' ? ' (Corp)' : ' (Runner)',
         player2_name: p.player2.name_with_pronouns,
+        player2_side: p.side == 'player1_is_corp' ? ' (Runner)' : ' (Corp)',
         pairing: p
       }
       pairings << {
         table_number: p.table_number,
         player1_name: p.player2.name_with_pronouns,
+        player1_side: p.side == 'player1_is_corp' ? ' (Runner)' : ' (Corp)',
         player2_name: p.player1.name_with_pronouns,
+        player2_side: p.side == 'player1_is_corp' ? ' (Corp)' : ' (Runner)',
         pairing: p
       }
     end.sort_by do |p|
-      # Sort by username for doublesided, but Corp username for Single-Sided Swiss.
-      if p[:pairing].round.stage.format == :single_sided_swiss.to_s
-        if p[:pairing].side == 'player1_is_corp'
-          p[:player1_name].downcase
-        else
-          p[:player2_name].downcase
-        end
-      else
-        p[:player1_name].downcase
-      end
+      p[:player1_name].downcase
     end
   end
 
@@ -59,11 +56,11 @@ class PairingsController < ApplicationController
   def match_slips
     authorize @tournament, :edit?
 
-    if params[:collate]
-      @pairings = round.collated_pairings
-    else
-      @pairings = round.pairings
-    end
+    @pairings = if params[:collate]
+                  round.collated_pairings
+                else
+                  round.pairings
+                end
   end
 
   def view_decks

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -143,6 +143,7 @@ class RoundsController < ApplicationController
   def pairing_player(stage, player, side)
     {
       name_with_pronouns: player.name_with_pronouns,
+      side:,
       side_label: side_label(stage, side),
       corp_id: pairing_identity(player.corp_identity_object),
       runner_id: pairing_identity(player.runner_identity_object)

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -36,6 +36,7 @@ class RoundsController < ApplicationController
             pairings: round.pairings.map { |pairing| {
               id: pairing.id,
               table_number: pairing.table_number,
+              is_single_sided_swiss: @tournament.swiss_format == :single_sided.to_s,
               policy: {
                 view_decks: view_decks
               },

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,11 +1,12 @@
 class RoundsController < ApplicationController
   before_action :set_tournament
-  before_action :set_round, only: [:show, :edit, :update, :destroy, :repair, :complete, :update_timer]
+  before_action :set_round, only: %i[show edit update destroy repair complete update_timer]
 
   def index
     authorize @tournament, :show?
     @stages = @tournament.stages.includes(
-      :tournament, rounds: [:tournament, :stage, pairings: [:tournament, :stage, :round]])
+      :tournament, rounds: [:tournament, :stage, { pairings: %i[tournament stage round] }]
+    )
     @players = @tournament.players
                           .includes(:corp_identity_ref, :runner_identity_ref)
                           .index_by(&:id).merge({ nil => NilPlayer.new })
@@ -18,38 +19,42 @@ class RoundsController < ApplicationController
   def pairings_data
     authorize @tournament, :show?
     stages = @tournament.stages.includes(
-      rounds: [pairings: [:player1, :player2]],
-      registrations: [player: [:user, :corp_identity_ref, :runner_identity_ref]]
+      rounds: [pairings: %i[player1 player2]],
+      registrations: [player: %i[user corp_identity_ref runner_identity_ref]]
     )
     render json: {
       policy: {
         update: @tournament.user == current_user
       },
       is_player_meeting: stages.all? { |stage| stage.rounds.empty? },
-      stages: stages.map { |stage|
+      stages: stages.map do |stage|
         view_decks = stage.decks_visible_to(current_user) ? true : false
         {
           name: stage.format.titleize,
-          rounds: stage.rounds.map { |round| {
-            id: round.id,
-            number: round.number,
-            pairings: round.pairings.map { |pairing| {
-              id: pairing.id,
-              table_number: pairing.table_number,
-              is_single_sided_swiss: @tournament.swiss_format == :single_sided.to_s,
-              policy: {
-                view_decks: view_decks
-              },
-              player1: pairing_player1(stage, pairing),
-              player2: pairing_player2(stage, pairing),
-              score_label: score_label(pairing),
-              intentional_draw: pairing.intentional_draw,
-              two_for_one: pairing.two_for_one
-            } },
-            pairings_reported: round.pairings.select { |p| p.score1 && p.score2 }.count,
-          } }
+          format: stage.format.to_sym,
+          rounds: stage.rounds.map do |round|
+                    {
+                      id: round.id,
+                      number: round.number,
+                      pairings: round.pairings.map do |pairing|
+                                  {
+                                    id: pairing.id,
+                                    table_number: pairing.table_number,
+                                    policy: {
+                                      view_decks:
+                                    },
+                                    player1: pairing_player1(stage, pairing),
+                                    player2: pairing_player2(stage, pairing),
+                                    score_label: score_label(pairing),
+                                    intentional_draw: pairing.intentional_draw,
+                                    two_for_one: pairing.two_for_one
+                                  }
+                                end,
+                      pairings_reported: round.pairings.select { |p| p.score1 && p.score2 }.count
+                    }
+                  end
         }
-      }
+      end
     }
   end
 
@@ -111,11 +116,11 @@ class RoundsController < ApplicationController
     @round.update!(length_minutes: params[:length_minutes])
 
     operation = params[:operation]
-    if operation == "start"
+    if operation == 'start'
       @round.timer.start!
-    elsif operation == "stop"
+    elsif operation == 'stop'
       @round.timer.stop!
-    elsif operation == "reset"
+    elsif operation == 'reset'
       @round.timer.reset!
     end
 
@@ -157,6 +162,7 @@ class RoundsController < ApplicationController
 
   def pairing_identity(identity)
     return nil unless identity
+
     {
       name: identity.name,
       faction: identity.faction
@@ -164,7 +170,8 @@ class RoundsController < ApplicationController
   end
 
   def score_label(pairing)
-    return "-" if pairing.score1 == 0 && pairing.score2 == 0
+    return '-' if pairing.score1 == 0 && pairing.score2 == 0
+
     ws = winning_side(pairing)
 
     return "#{pairing.score1} - #{pairing.score2}" unless ws
@@ -176,10 +183,9 @@ class RoundsController < ApplicationController
     corp_score = (pairing.score1_corp || 0) + (pairing.score2_corp || 0)
     runner_score = (pairing.score1_runner || 0) + (pairing.score2_runner || 0)
 
-    case
-    when corp_score - runner_score == 0
+    if corp_score - runner_score == 0
       nil
-    when corp_score - runner_score < 0
+    elsif corp_score - runner_score < 0
       'R'
     else
       'C'

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -1,12 +1,11 @@
 class RoundsController < ApplicationController
   before_action :set_tournament
-  before_action :set_round, only: %i[show edit update destroy repair complete update_timer]
+  before_action :set_round, only: [:show, :edit, :update, :destroy, :repair, :complete, :update_timer]
 
   def index
     authorize @tournament, :show?
     @stages = @tournament.stages.includes(
-      :tournament, rounds: [:tournament, :stage, { pairings: %i[tournament stage round] }]
-    )
+      :tournament, rounds: [:tournament, :stage, pairings: [:tournament, :stage, :round]])
     @players = @tournament.players
                           .includes(:corp_identity_ref, :runner_identity_ref)
                           .index_by(&:id).merge({ nil => NilPlayer.new })
@@ -19,42 +18,38 @@ class RoundsController < ApplicationController
   def pairings_data
     authorize @tournament, :show?
     stages = @tournament.stages.includes(
-      rounds: [pairings: %i[player1 player2]],
-      registrations: [player: %i[user corp_identity_ref runner_identity_ref]]
+      rounds: [pairings: [:player1, :player2]],
+      registrations: [player: [:user, :corp_identity_ref, :runner_identity_ref]]
     )
     render json: {
       policy: {
         update: @tournament.user == current_user
       },
       is_player_meeting: stages.all? { |stage| stage.rounds.empty? },
-      stages: stages.map do |stage|
+      stages: stages.map { |stage|
         view_decks = stage.decks_visible_to(current_user) ? true : false
         {
           name: stage.format.titleize,
-          format: stage.format.to_sym,
-          rounds: stage.rounds.map do |round|
-                    {
-                      id: round.id,
-                      number: round.number,
-                      pairings: round.pairings.map do |pairing|
-                                  {
-                                    id: pairing.id,
-                                    table_number: pairing.table_number,
-                                    policy: {
-                                      view_decks:
-                                    },
-                                    player1: pairing_player1(stage, pairing),
-                                    player2: pairing_player2(stage, pairing),
-                                    score_label: score_label(pairing),
-                                    intentional_draw: pairing.intentional_draw,
-                                    two_for_one: pairing.two_for_one
-                                  }
-                                end,
-                      pairings_reported: round.pairings.select { |p| p.score1 && p.score2 }.count
-                    }
-                  end
+          format: stage.format,
+          rounds: stage.rounds.map { |round| {
+            id: round.id,
+            number: round.number,
+            pairings: round.pairings.map { |pairing| {
+              id: pairing.id,
+              table_number: pairing.table_number,
+              policy: {
+                view_decks: view_decks
+              },
+              player1: pairing_player1(stage, pairing),
+              player2: pairing_player2(stage, pairing),
+              score_label: score_label(pairing),
+              intentional_draw: pairing.intentional_draw,
+              two_for_one: pairing.two_for_one
+            } },
+            pairings_reported: round.pairings.select { |p| p.score1 && p.score2 }.count,
+          } }
         }
-      end
+      }
     }
   end
 
@@ -116,11 +111,11 @@ class RoundsController < ApplicationController
     @round.update!(length_minutes: params[:length_minutes])
 
     operation = params[:operation]
-    if operation == 'start'
+    if operation == "start"
       @round.timer.start!
-    elsif operation == 'stop'
+    elsif operation == "stop"
       @round.timer.stop!
-    elsif operation == 'reset'
+    elsif operation == "reset"
       @round.timer.reset!
     end
 
@@ -162,7 +157,6 @@ class RoundsController < ApplicationController
 
   def pairing_identity(identity)
     return nil unless identity
-
     {
       name: identity.name,
       faction: identity.faction
@@ -170,8 +164,7 @@ class RoundsController < ApplicationController
   end
 
   def score_label(pairing)
-    return '-' if pairing.score1 == 0 && pairing.score2 == 0
-
+    return "-" if pairing.score1 == 0 && pairing.score2 == 0
     ws = winning_side(pairing)
 
     return "#{pairing.score1} - #{pairing.score2}" unless ws
@@ -183,9 +176,10 @@ class RoundsController < ApplicationController
     corp_score = (pairing.score1_corp || 0) + (pairing.score2_corp || 0)
     runner_score = (pairing.score1_runner || 0) + (pairing.score2_runner || 0)
 
-    if corp_score - runner_score == 0
+    case
+    when corp_score - runner_score == 0
       nil
-    elsif corp_score - runner_score < 0
+    when corp_score - runner_score < 0
       'R'
     else
       'C'

--- a/app/frontend/pairings/Pairing.svelte
+++ b/app/frontend/pairings/Pairing.svelte
@@ -6,8 +6,8 @@
     export let stage: Stage;
     export let round: Round;
     export let pairing: Pairing;
-    export let left_player = pairing.player1
-    export let right_player = pairing.player2
+    let left_player = pairing.player1
+    let right_player = pairing.player2
     if (stage.format == 'single_sided_swiss' && pairing.player2.side == 'corp') {
         left_player = pairing.player2
         right_player = pairing.player1

--- a/app/frontend/pairings/Pairing.svelte
+++ b/app/frontend/pairings/Pairing.svelte
@@ -8,7 +8,7 @@
     export let pairing: Pairing;
     export let left_player = pairing.player1
     export let right_player = pairing.player2
-    if (stage.format == 'single_sided_swiss' && pairing.player2.side_label == '(Corp)') {
+    if (stage.format == 'single_sided_swiss' && pairing.player2.side == 'corp') {
         left_player = pairing.player2
         right_player = pairing.player1
     }

--- a/app/frontend/pairings/Pairing.svelte
+++ b/app/frontend/pairings/Pairing.svelte
@@ -5,6 +5,12 @@
 
     export let round: Round;
     export let pairing: Pairing;
+    export let left_player = pairing.player1
+    export let right_player = pairing.player2
+    if (pairing.is_single_sided_swiss && pairing.player2.side_label == '(Corp)') {
+        left_player = pairing.player2
+        right_player = pairing.player1
+    }
 </script>
 
 <div class="row m-1 round_pairing align-items-center table_{pairing.table_number}">
@@ -17,7 +23,7 @@
             View decks
         </a>
     {/if}
-    <PlayerName player={pairing.player1} left_or_right="left"/>
+    <PlayerName player={left_player} left_or_right="left"/>
     <div class="col-sm-2 centre_score">
         {pairing.score_label}
         {#if pairing.intentional_draw}
@@ -27,5 +33,5 @@
             <span class="badge badge-pill badge-secondary score-badge">2 for 1</span>
         {/if}
     </div>
-    <PlayerName player={pairing.player2} left_or_right="right"/>
+    <PlayerName player={right_player} left_or_right="right"/>
 </div>

--- a/app/frontend/pairings/Pairing.svelte
+++ b/app/frontend/pairings/Pairing.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-    import type {Pairing, Round} from "./PairingsData";
+    import type {Pairing, Round, Stage} from "./PairingsData";
     import PlayerName from "./PlayerName.svelte";
     import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
 
+    export let stage: Stage;
     export let round: Round;
     export let pairing: Pairing;
     export let left_player = pairing.player1
     export let right_player = pairing.player2
-    if (pairing.is_single_sided_swiss && pairing.player2.side_label == '(Corp)') {
+    if (stage.format == 'single_sided_swiss' && pairing.player2.side_label == '(Corp)') {
         left_player = pairing.player2
         right_player = pairing.player1
     }

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -54,6 +54,7 @@ export type PairingPolicies = {
 
 export type Player = {
     name_with_pronouns: string;
+    side: string | null;
     side_label: string | null;
     corp_id: Identity | null;
     runner_id: Identity | null;

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -39,6 +39,7 @@ export type Round = {
 export type Pairing = {
     id: number;
     table_number: number;
+    is_single_sided_swiss: boolean;
     policy: PairingPolicies;
     player1: Player;
     player2: Player;

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -26,6 +26,7 @@ export type TournamentPolicies = {
 
 export type Stage = {
     name: string;
+    format: string;
     rounds: Round[];
 }
 
@@ -39,7 +40,6 @@ export type Round = {
 export type Pairing = {
     id: number;
     table_number: number;
-    is_single_sided_swiss: boolean;
     policy: PairingPolicies;
     player1: Player;
     player2: Player;

--- a/app/frontend/pairings/PlayerName.svelte
+++ b/app/frontend/pairings/PlayerName.svelte
@@ -13,7 +13,7 @@
     {/if}
     <div class="ids" style="{$showIdentities ? 'display: block;' : ''}">
         {#if player.side_label}
-            <Identity identity={player.side_label == '(Corp)' ? player.corp_id : player.runner_id }/>
+            <Identity identity={player.side == 'corp' ? player.corp_id : player.runner_id }/>
         {:else}
             <Identity identity={player.corp_id}/>
             <Identity identity={player.runner_id}/>

--- a/app/frontend/pairings/PlayerName.svelte
+++ b/app/frontend/pairings/PlayerName.svelte
@@ -12,7 +12,11 @@
         {player.side_label}
     {/if}
     <div class="ids" style="{$showIdentities ? 'display: block;' : ''}">
-        <Identity identity={player.corp_id}/>
-        <Identity identity={player.runner_id}/>
+        {#if player.side_label}
+            <Identity identity={player.side_label == '(Corp)' ? player.corp_id : player.runner_id }/>
+        {:else}
+            <Identity identity={player.corp_id}/>
+            <Identity identity={player.runner_id}/>
+        {/if}
     </div>
 </div>

--- a/app/frontend/pairings/Round.svelte
+++ b/app/frontend/pairings/Round.svelte
@@ -2,7 +2,9 @@
     import type {Round} from "./PairingsData";
     import Pairing from "./Pairing.svelte";
     import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+    import Stage from "./Stage.svelte";
 
+    export let stage: Stage;
     export let round: Round;
     export let start_expanded: boolean;
 </script>
@@ -28,7 +30,7 @@
                 Pairings by name
             </a>
             {#each round.pairings as pairing}
-                <Pairing pairing={pairing} round="{round}"/>
+                <Pairing pairing={pairing} round="{round}" stage={stage} />
             {/each}
         </div>
     </div>

--- a/app/frontend/pairings/Stage.svelte
+++ b/app/frontend/pairings/Stage.svelte
@@ -13,6 +13,6 @@
         </div>
     </div>
     {#each stage.rounds as round, index}
-        <Round round={round} start_expanded={start_expanded && index === stage.rounds.length - 1}/>
+        <Round round={round} stage={stage} start_expanded={start_expanded && index === stage.rounds.length - 1}/>
     {/each}
 </div>

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -46,6 +46,7 @@ module PairingsHelper
   end
 
   def presets(pairing)
+    # Double-sided round
     return [
       { score1_corp: 3, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '6-0' },
       { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '3-3 (C)' },
@@ -53,6 +54,32 @@ module PairingsHelper
       { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 3, label: '0-6' }
     ] unless pairing.stage.single_sided?
 
+    # Single-sided swiss round
+    if pairing.round.stage.format == :single_sided_swiss.to_s
+      if pairing.side.try(:to_sym) == :player1_is_corp
+        return [
+          { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+            label: 'Corp Win' },
+          { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false, label: 'Tie' },
+          { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+            label: 'Runner Win' },
+          { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
+            label: 'Intentional Draw' }
+        ]
+      else
+        return [
+          { score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 3, intentional_draw: false,
+            label: 'Corp Win' },
+          { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false, label: 'Tie' },
+          { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, intentional_draw: false,
+            label: 'Runner Win' },
+          { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
+            label: 'Intentional Draw' }
+        ]
+      end
+    end
+
+    # Single-sided elimination round
     return [
       { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
       { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: '0-3' }

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -61,10 +61,10 @@ module PairingsHelper
           { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, intentional_draw: false,
             label: 'Corp Win' },
           { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false, label: 'Tie' },
-          { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
-            label: 'Runner Win' },
           { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
-            label: 'Intentional Draw' }
+            label: 'Intentional Draw' },
+          { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+            label: 'Runner Win' }
         ]
       else
         return [

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -57,8 +57,8 @@ module PairingsHelper
     end
 
     # Single-sided swiss round
-    if pairing.round.stage.format == :single_sided_swiss.to_s
-      if pairing.side.try(:to_sym) == :player1_is_corp
+    if pairing.stage.single_sided_swiss?
+      if pairing.player1_is_corp?
         return [
           { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, intentional_draw: false,
             label: 'Corp Win' },
@@ -82,14 +82,14 @@ module PairingsHelper
     end
 
     # Single-sided elimination round
-    if pairing.side.try(:to_sym) == :player1_is_corp
+    if pairing.player1_is_corp?
       return [
         { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
         { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: '0-3' }
       ]
     end
 
-    if pairing.side.try(:to_sym) == :player1_is_runner
+    if pairing.player1_is_runner?
       return [
         { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '3-0' },
         { score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '0-3' }

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -23,7 +23,7 @@ module PairingsHelper
   def side_value(player, side, pairing)
     return unless player_is_in_pairing(player, pairing)
 
-    [:player1_is_corp, :player1_is_runner].tap do |options|
+    %i[player1_is_corp player1_is_runner].tap do |options|
       options.reverse! if (side == :runner) ^ (pairing.player2_id == player.id)
     end.first
   end
@@ -47,12 +47,14 @@ module PairingsHelper
 
   def presets(pairing)
     # Double-sided round
-    return [
-      { score1_corp: 3, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '6-0' },
-      { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '3-3 (C)' },
-      { score1_corp: 0, score2_runner: 3, score1_runner: 3, score2_corp: 0, label: '3-3 (R)' },
-      { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 3, label: '0-6' }
-    ] unless pairing.stage.single_sided?
+    unless pairing.stage.single_sided?
+      return [
+        { score1_corp: 3, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '6-0' },
+        { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '3-3 (C)' },
+        { score1_corp: 0, score2_runner: 3, score1_runner: 3, score2_corp: 0, label: '3-3 (R)' },
+        { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 3, label: '0-6' }
+      ]
+    end
 
     # Single-sided swiss round
     if pairing.round.stage.format == :single_sided_swiss.to_s
@@ -71,24 +73,28 @@ module PairingsHelper
           { score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 3, intentional_draw: false,
             label: 'Corp Win' },
           { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false, label: 'Tie' },
-          { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, intentional_draw: false,
-            label: 'Runner Win' },
           { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
-            label: 'Intentional Draw' }
+            label: 'Intentional Draw' },
+          { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, intentional_draw: false,
+            label: 'Runner Win' }
         ]
       end
     end
 
     # Single-sided elimination round
-    return [
-      { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
-      { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: '0-3' }
-    ] if pairing.side.try(:to_sym) == :player1_is_corp
+    if pairing.side.try(:to_sym) == :player1_is_corp
+      return [
+        { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
+        { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: '0-3' }
+      ]
+    end
 
-    return [
-      { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '3-0' },
-      { score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '0-3' }
-    ] if pairing.side.try(:to_sym) == :player1_is_runner
+    if pairing.side.try(:to_sym) == :player1_is_runner
+      return [
+        { score1_corp: 0, score2_runner: 0, score1_runner: 3, score2_corp: 0, label: '3-0' },
+        { score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 3, label: '0-3' }
+      ]
+    end
 
     [
       { score1: 3, score2: 0, score1_corp: 0, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
@@ -111,7 +117,8 @@ module PairingsHelper
   end
 
   def readable_score(pairing)
-    return "-" if pairing.score1 == 0 && pairing.score2 == 0
+    return '-' if pairing.score1 == 0 && pairing.score2 == 0
+
     ws = winning_side(pairing)
 
     return "#{pairing.score1} - #{pairing.score2}" unless ws
@@ -123,10 +130,9 @@ module PairingsHelper
     corp_score = (pairing.score1_corp || 0) + (pairing.score2_corp || 0)
     runner_score = (pairing.score1_runner || 0) + (pairing.score2_runner || 0)
 
-    case
-    when corp_score - runner_score == 0
+    if corp_score - runner_score == 0
       nil
-    when corp_score - runner_score < 0
+    elsif corp_score - runner_score < 0
       'R'
     else
       'C'

--- a/app/views/pairings/index.html.slim
+++ b/app/views/pairings/index.html.slim
@@ -24,12 +24,18 @@ ruby:
               => fa_icon 'eye'
               | View decks
           td
-            =p[:player1_name]
             - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
-              <br />
-              = render p[:pairing].player1_is_corp? ? p[:pairing].player1.corp_identity_object : p[:pairing].player1.runner_identity_object
+              - if p[:pairing].side == 'player1_is_corp'
+                = p[:player1_name] + ' (Corp)'
+              - else
+                = p[:player2_name] + ' (Corp)'
+            - else
+              = p[:player1_name]
           td
-            = p[:player2_name]
             - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
-              <br />
-              = render p[:pairing].player1_is_corp? ? p[:pairing].player2.runner_identity_object : p[:pairing].player2.corp_identity_object
+              - if p[:pairing].side == 'player1_is_corp'
+                = p[:player2_name] + ' (Runner)'
+              - else
+                = p[:player1_name] + ' (Runner)'
+            - else
+              = p[:player2_name]

--- a/app/views/pairings/index.html.slim
+++ b/app/views/pairings/index.html.slim
@@ -23,5 +23,13 @@ ruby:
             td= link_to view_decks_tournament_round_pairing_path(@tournament, @round, p[:pairing]), class: 'ml-2' do
               => fa_icon 'eye'
               | View decks
-          td= p[:player1_name]
-          td= p[:player2_name]
+          td
+            =p[:player1_name]
+            - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
+              <br />
+              = render p[:pairing].player1_is_corp? ? p[:pairing].player1.corp_identity_object : p[:pairing].player1.runner_identity_object
+          td
+            = p[:player2_name]
+            - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
+              <br />
+              = render p[:pairing].player1_is_corp? ? p[:pairing].player2.runner_identity_object : p[:pairing].player2.corp_identity_object

--- a/app/views/pairings/index.html.slim
+++ b/app/views/pairings/index.html.slim
@@ -25,17 +25,11 @@ ruby:
               | View decks
           td
             - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
-              - if p[:pairing].side == 'player1_is_corp'
-                = p[:player1_name] + ' (Corp)'
-              - else
-                = p[:player2_name] + ' (Corp)'
+              = p[:player1_name] + p[:player1_side]
             - else
               = p[:player1_name]
           td
             - if p[:pairing].round.stage.format == :single_sided_swiss.to_s
-              - if p[:pairing].side == 'player1_is_corp'
-                = p[:player2_name] + ' (Runner)'
-              - else
-                = p[:player1_name] + ' (Runner)'
+              = p[:player2_name] + p[:player2_side]
             - else
               = p[:player2_name]

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -1,5 +1,10 @@
 - single_sided = round.stage.single_sided?
 - round.pairings.each do |pairing|
+  - left_player = @players[pairing.player1_id]
+  - right_player = @players[pairing.player2_id]
+  - if single_sided && !pairing.player1_is_corp?
+    - left_player = @players[pairing.player2_id]
+    - right_player = @players[pairing.player1_id]
   .row.m-1.round_pairing.align-items-center class="table_#{pairing.table_number} #{'reported' if pairing.reported? && current_user == @tournament.user}"
     .col-sm-2
       | Table #{pairing.table_number}
@@ -24,19 +29,16 @@
         => fa_icon 'eye'
         | View decks
     .col-sm.left_player_name
-      = @players[pairing.player1_id].name_with_pronouns
+      = left_player.name_with_pronouns
       <br />
-      =< render 'player_side', pairing: pairing, player: @players[pairing.player1_id], single_sided: single_sided
-      - if @players[pairing.player1_id].id
+      =< render 'player_side', pairing: pairing, player: left_player, single_sided: single_sided
+      - if left_player.id
         .ids
           - if round.stage.single_sided?
-            - if pairing.player1_is_corp?
-              = render @players[pairing.player1_id].corp_identity_object
-            -else
-              = render @players[pairing.player1_id].runner_identity_object
+            = render left_player.corp_identity_object
           - else
-            = render @players[pairing.player1_id].corp_identity_object
-            = render @players[pairing.player1_id].runner_identity_object
+            = render left_player.corp_identity_object
+            = render left_player.runner_identity_object
     - if policy(round.tournament).edit?
       .col-sm-5.centre_score
         .preset_score
@@ -75,18 +77,16 @@
           span class='badge badge-pill badge-secondary score-badge'
             | 2 for 1
     .col-sm.right_player_name
-      = @players[pairing.player2_id].name_with_pronouns
-      =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided
-      - if @players[pairing.player2_id].id
+      = right_player.name_with_pronouns
+      <br />
+      =< render 'player_side', pairing: pairing, player: right_player, single_sided: single_sided
+      - if right_player.id
         .ids
           - if round.stage.single_sided?
-            - if !pairing.player1_is_corp?
-              = render @players[pairing.player2_id].corp_identity_object
-            -else
-              = render @players[pairing.player2_id].runner_identity_object
+            = render right_player.runner_identity_object
           - else
-            = render @players[pairing.player2_id].corp_identity_object
-            = render @players[pairing.player2_id].runner_identity_object
+            = render right_player.corp_identity_object
+            = render right_player.runner_identity_object
     - if policy(round.tournament).update?
       .col-sm-1
         = link_to tournament_round_pairing_path(round.tournament, round, pairing), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -25,17 +25,25 @@
         | View decks
     .col-sm.left_player_name
       = @players[pairing.player1_id].name_with_pronouns
+      <br />
       =< render 'player_side', pairing: pairing, player: @players[pairing.player1_id], single_sided: single_sided
       - if @players[pairing.player1_id].id
         .ids
-          = render @players[pairing.player1_id].corp_identity_object
-          = render @players[pairing.player1_id].runner_identity_object
+          - if round.stage.single_sided?
+            - if pairing.player1_is_corp?
+              = render @players[pairing.player1_id].corp_identity_object
+            -else
+              = render @players[pairing.player1_id].runner_identity_object
+          - else
+            = render @players[pairing.player1_id].corp_identity_object
+            = render @players[pairing.player1_id].runner_identity_object
     - if policy(round.tournament).edit?
       .col-sm-5.centre_score
         .preset_score
           - presets(pairing).each do |data|
             => preset_score_button pairing, data
-          = link_to '...', '#', class: 'btn btn-primary toggle_custom_score'
+          - unless round.stage.single_sided?
+            = link_to '...', '#', class: 'btn btn-primary toggle_custom_score'
         .custom_score
           = simple_form_for pairing, url: report_tournament_round_pairing_path(round.tournament, round, pairing), method: :post, html: { class: 'form-inline' } do |f|
             .mx-auto
@@ -52,26 +60,33 @@
               div class='form-group'
                 div class='form-check form-check-inline'
                   = f.check_box :intentional_draw, class: 'form-check-input'
-                  = f.label :intentional_draw, 'ID', class: 'form-check-label'
-                div class='form-check form-check-inline'
-                  = f.check_box :two_for_one, class: 'form-check-input' 
-                  = f.label :two_for_one, '2 for 1', class: 'form-check-label'
+                  = f.label :intentional_draw, 'Intentional Draw', class: 'form-check-label'
+                - unless round.stage.single_sided?
+                  div class='form-check form-check-inline'
+                    = f.check_box :two_for_one, class: 'form-check-input'
+                    = f.label :two_for_one, '2 for 1', class: 'form-check-label'
     - else
       .col-sm-2.centre_score
         = readable_score(pairing)
         - if pairing.intentional_draw
-          span class='badge badge-pill badge-secondary score-badge' 
+          span class='badge badge-pill badge-secondary score-badge'
             | ID
         - if pairing.two_for_one
-          span class='badge badge-pill badge-secondary score-badge' 
+          span class='badge badge-pill badge-secondary score-badge'
             | 2 for 1
     .col-sm.right_player_name
       = @players[pairing.player2_id].name_with_pronouns
       =< render 'player_side', pairing: pairing, player: @players[pairing.player2_id], single_sided: single_sided
       - if @players[pairing.player2_id].id
         .ids
-          = render @players[pairing.player2_id].corp_identity_object
-          = render @players[pairing.player2_id].runner_identity_object
+          - if round.stage.single_sided?
+            - if !pairing.player1_is_corp?
+              = render @players[pairing.player2_id].corp_identity_object
+            -else
+              = render @players[pairing.player2_id].runner_identity_object
+          - else
+            = render @players[pairing.player2_id].corp_identity_object
+            = render @players[pairing.player2_id].runner_identity_object
     - if policy(round.tournament).update?
       .col-sm-1
         = link_to tournament_round_pairing_path(round.tournament, round, pairing), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure? This cannot be reversed.' } do

--- a/app/views/tournaments/_form.html.slim
+++ b/app/views/tournaments/_form.html.slim
@@ -2,7 +2,7 @@
   = f.input :name, input_html: { class: 'form-control' }, label: 'Tournament name'
 .form-group
   = f.input :date, html5: true, input_html: { class: 'form-control' }
-- if Flipper.enabled? :single_sided_swiss
+- if Flipper.enabled?(:single_sided_swiss, current_user)
   .form-group
     = f.input :swiss_format, collection: Tournament.swiss_formats.keys, input_html: { class: 'form-control' }, include_blank: false, label_method: ->(val) { val.capitalize.tr('_', '-') }
 .form-group

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -1,10 +1,34 @@
 RSpec.describe PairingsHelper do
+  describe '#single_sided_swiss_presets' do
+    let(:tournament) { create(:tournament, swiss_format: :single_sided) }
+    let(:stage) { tournament.current_stage }
+
+    context 'when player 1 is corp' do
+      let(:pairing) { create(:pairing, stage: stage, side: :player1_is_corp) }
+
+      it 'returns single-sided swiss defaults' do
+        expect(helper.presets(pairing)).to eq(
+          [
+            { score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+              label: 'Corp Win' },
+            { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+              label: 'Tie' },
+            { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+              label: 'Runner Win' },
+            { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
+              label: 'Intentional Draw' }
+          ]
+        )
+      end
+    end
+  end
+
   describe '#presets' do
     let(:tournament) { create(:tournament) }
     let(:stage) { tournament.current_stage }
     let(:pairing) { create(:pairing, stage: stage) }
 
-    context 'for swiss' do
+    context 'for double-sided swiss' do
       it 'returns swiss defaults' do
         expect(helper.presets(pairing)).to eq(
           [

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe PairingsHelper do
               label: 'Corp Win' },
             { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: false,
               label: 'Tie' },
-            { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
-              label: 'Runner Win' },
             { score1_corp: 1, score2_runner: 1, score1_runner: 0, score2_corp: 0, intentional_draw: true,
-              label: 'Intentional Draw' }
+              label: 'Intentional Draw' },
+            { score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, intentional_draw: false,
+              label: 'Runner Win' }
           ]
         )
       end

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -168,11 +168,12 @@ RSpec.describe RoundsController do
       'name_with_pronouns' => name_with_pronouns,
       'corp_id' => { 'faction' => nil, 'name' => nil },
       'runner_id' => { 'faction' => nil, 'name' => nil },
+      'side' => nil,
       'side_label' => nil
     }
   end
 
   def bye_player
-    { 'corp_id' => nil, 'name_with_pronouns' => '(Bye)', 'runner_id' => nil, 'side_label' => nil }
+    { 'corp_id' => nil, 'name_with_pronouns' => '(Bye)', 'runner_id' => nil, 'side' => nil, 'side_label' => nil }
   end
 end

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe RoundsController do
-
   describe 'pairings data' do
     let(:organiser) { create(:user) }
     let(:tournament) { create(:tournament, name: 'My Tournament', user: organiser) }
-    let!(:alice) { create(:player, tournament: tournament, name: 'Alice', pronouns: 'she/her') }
-    let!(:bob) { create(:player, tournament: tournament, name: 'Bob', pronouns: 'he/him') }
-    let!(:charlie) { create(:player, tournament: tournament, name: 'Charlie', pronouns: 'she/her') }
+    let!(:alice) { create(:player, tournament:, name: 'Alice', pronouns: 'she/her') }
+    let!(:bob) { create(:player, tournament:, name: 'Bob', pronouns: 'he/him') }
+    let!(:charlie) { create(:player, tournament:, name: 'Charlie', pronouns: 'she/her') }
 
     describe 'during player meeting' do
       it 'displays without logging in' do
@@ -14,10 +13,10 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-                'is_player_meeting' => true,
-                'policy' => { 'update' => false },
-                'stages' => [{ 'name' => 'Swiss', 'rounds' => [] }]
-              )
+            'is_player_meeting' => true,
+            'policy' => { 'update' => false },
+            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+          )
       end
       it 'displays as player' do
         sign_in alice
@@ -25,10 +24,10 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-                'is_player_meeting' => true,
-                'policy' => { 'update' => false },
-                'stages' => [{ 'name' => 'Swiss', 'rounds' => [] }]
-              )
+            'is_player_meeting' => true,
+            'policy' => { 'update' => false },
+            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+          )
       end
       it 'displays as organiser' do
         sign_in organiser
@@ -36,10 +35,10 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-                'is_player_meeting' => true,
-                'policy' => { 'update' => true },
-                'stages' => [{ 'name' => 'Swiss', 'rounds' => [] }]
-              )
+            'is_player_meeting' => true,
+            'policy' => { 'update' => true },
+            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+          )
       end
     end
 
@@ -54,23 +53,22 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
-                   'stages' => [{ 'name' => 'Swiss', 'rounds' => [
+                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
                      {
-                       "number" => 1,
-                       "pairings" => [
-                         { "intentional_draw" => false,
-                           "is_single_sided_swiss" => false,
-                           "player1" => player_with_no_ids("Charlie (she/her)"),
-                           "player2" => player_with_no_ids("Bob (he/him)"),
-                           "policy" => { "view_decks" => false },
-                           "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
-                         { "intentional_draw" => false,
-                           "is_single_sided_swiss" => false,
-                           "player1" => player_with_no_ids("Alice (she/her)"),
-                           "player2" => bye_player,
-                           "policy" => { "view_decks" => false },
-                           "score_label" => "6 - 0", "table_number" => 2, "two_for_one" => false }
-                       ], "pairings_reported" => 1 }
+                       'number' => 1,
+                       'pairings' => [
+                         { 'intentional_draw' => false,
+                           'player1' => player_with_no_ids('Charlie (she/her)'),
+                           'player2' => player_with_no_ids('Bob (he/him)'),
+                           'policy' => { 'view_decks' => false },
+                           'score_label' => ' - ', 'table_number' => 1, 'two_for_one' => false },
+                         { 'intentional_draw' => false,
+                           'player1' => player_with_no_ids('Alice (she/her)'),
+                           'player2' => bye_player,
+                           'policy' => { 'view_decks' => false },
+                           'score_label' => '6 - 0', 'table_number' => 2, 'two_for_one' => false }
+                       ], 'pairings_reported' => 1
+                     }
                    ] }]
                  })
       end
@@ -81,23 +79,22 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => true },
-                   'stages' => [{ 'name' => 'Swiss', 'rounds' => [
+                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
                      {
-                       "number" => 1,
-                       "pairings" => [
-                         { "intentional_draw" => false,
-                           "is_single_sided_swiss" => false,
-                           "player1" => player_with_no_ids("Charlie (she/her)"),
-                           "player2" => player_with_no_ids("Bob (he/him)"),
-                           "policy" => { "view_decks" => false }, # sees player view as a player
-                           "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
-                         { "intentional_draw" => false,
-                           "is_single_sided_swiss" => false,
-                           "player1" => player_with_no_ids("Alice (she/her)"),
-                           "player2" => bye_player,
-                           "policy" => { "view_decks" => false }, # sees player view as a player
-                           "score_label" => "6 - 0", "table_number" => 2, "two_for_one" => false }
-                       ], "pairings_reported" => 1 }
+                       'number' => 1,
+                       'pairings' => [
+                         { 'intentional_draw' => false,
+                           'player1' => player_with_no_ids('Charlie (she/her)'),
+                           'player2' => player_with_no_ids('Bob (he/him)'),
+                           'policy' => { 'view_decks' => false }, # sees player view as a player
+                           'score_label' => ' - ', 'table_number' => 1, 'two_for_one' => false },
+                         { 'intentional_draw' => false,
+                           'player1' => player_with_no_ids('Alice (she/her)'),
+                           'player2' => bye_player,
+                           'policy' => { 'view_decks' => false }, # sees player view as a player
+                           'score_label' => '6 - 0', 'table_number' => 2, 'two_for_one' => false }
+                       ], 'pairings_reported' => 1
+                     }
                    ] }]
                  })
       end
@@ -117,37 +114,36 @@ RSpec.describe RoundsController do
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
                    'stages' => [
-                     { 'name' => 'Swiss', 'rounds' => [
+                     { 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
                        {
-                         "number" => 1,
-                         "pairings" => [
-                           { "intentional_draw" => false,
-                             "is_single_sided_swiss" => false,
-                             "player1" => player_with_no_ids("Charlie (she/her)"),
-                             "player2" => player_with_no_ids("Bob (he/him)"),
-                             "policy" => { "view_decks" => false },
-                             "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
-                           { "intentional_draw" => false,
-                             "is_single_sided_swiss" => false,
-                             "player1" => player_with_no_ids("Alice (she/her)"),
-                             "player2" => bye_player,
-                             "policy" => { "view_decks" => false },
-                             "score_label" => "6 - 0", "table_number" => 2, "two_for_one" => false }
-                         ], "pairings_reported" => 1
-                       }] },
-                     { 'name' => 'Double Elim', 'rounds' => [
-                       {
-                         "number" => 1,
-                         "pairings" => [
-                           { "intentional_draw" => false,
-                             "is_single_sided_swiss" => false,
-                             "player1" => player_with_no_ids("Bob (he/him)"),
-                             "player2" => player_with_no_ids("Charlie (she/her)"),
-                             "policy" => { "view_decks" => false },
-                             "score_label" => " - ", "table_number" => 1, "two_for_one" => false }
-                         ], "pairings_reported" => 0
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Charlie (she/her)'),
+                             'player2' => player_with_no_ids('Bob (he/him)'),
+                             'policy' => { 'view_decks' => false },
+                             'score_label' => ' - ', 'table_number' => 1, 'two_for_one' => false },
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Alice (she/her)'),
+                             'player2' => bye_player,
+                             'policy' => { 'view_decks' => false },
+                             'score_label' => '6 - 0', 'table_number' => 2, 'two_for_one' => false }
+                         ], 'pairings_reported' => 1
                        }
-                     ] }]
+                     ] },
+                     { 'name' => 'Double Elim', 'format' => 'double_elim', 'rounds' => [
+                       {
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Bob (he/him)'),
+                             'player2' => player_with_no_ids('Charlie (she/her)'),
+                             'policy' => { 'view_decks' => false },
+                             'score_label' => ' - ', 'table_number' => 1, 'two_for_one' => false }
+                         ], 'pairings_reported' => 0
+                       }
+                     ] }
+                   ]
                  })
       end
     end
@@ -155,28 +151,28 @@ RSpec.describe RoundsController do
 
   def compare_body(response)
     body = JSON.parse(response.body)
-    body['stages'].each { |stage|
+    body['stages'].each do |stage|
       stage.delete 'id'
-      stage['rounds'].each { |round|
+      stage['rounds'].each do |round|
         round.delete 'id'
-        round['pairings'].each { |pairing|
+        round['pairings'].each do |pairing|
           pairing.delete 'id'
-        }
-      }
-    }
+        end
+      end
+    end
     body
   end
 
   def player_with_no_ids(name_with_pronouns)
     {
-      "name_with_pronouns" => name_with_pronouns,
-      "corp_id" => { "faction" => nil, "name" => nil },
-      "runner_id" => { "faction" => nil, "name" => nil },
-      "side_label" => nil
+      'name_with_pronouns' => name_with_pronouns,
+      'corp_id' => { 'faction' => nil, 'name' => nil },
+      'runner_id' => { 'faction' => nil, 'name' => nil },
+      'side_label' => nil
     }
   end
 
   def bye_player
-    { "corp_id" => nil, "name_with_pronouns" => "(Bye)", "runner_id" => nil, "side_label" => nil }
+    { 'corp_id' => nil, 'name_with_pronouns' => '(Bye)', 'runner_id' => nil, 'side_label' => nil }
   end
 end

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -59,11 +59,13 @@ RSpec.describe RoundsController do
                        "number" => 1,
                        "pairings" => [
                          { "intentional_draw" => false,
+                           "is_single_sided_swiss" => false,
                            "player1" => player_with_no_ids("Charlie (she/her)"),
                            "player2" => player_with_no_ids("Bob (he/him)"),
                            "policy" => { "view_decks" => false },
                            "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
                          { "intentional_draw" => false,
+                           "is_single_sided_swiss" => false,
                            "player1" => player_with_no_ids("Alice (she/her)"),
                            "player2" => bye_player,
                            "policy" => { "view_decks" => false },
@@ -84,11 +86,13 @@ RSpec.describe RoundsController do
                        "number" => 1,
                        "pairings" => [
                          { "intentional_draw" => false,
+                           "is_single_sided_swiss" => false,
                            "player1" => player_with_no_ids("Charlie (she/her)"),
                            "player2" => player_with_no_ids("Bob (he/him)"),
                            "policy" => { "view_decks" => false }, # sees player view as a player
                            "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
                          { "intentional_draw" => false,
+                           "is_single_sided_swiss" => false,
                            "player1" => player_with_no_ids("Alice (she/her)"),
                            "player2" => bye_player,
                            "policy" => { "view_decks" => false }, # sees player view as a player
@@ -118,11 +122,13 @@ RSpec.describe RoundsController do
                          "number" => 1,
                          "pairings" => [
                            { "intentional_draw" => false,
+                             "is_single_sided_swiss" => false,
                              "player1" => player_with_no_ids("Charlie (she/her)"),
                              "player2" => player_with_no_ids("Bob (he/him)"),
                              "policy" => { "view_decks" => false },
                              "score_label" => " - ", "table_number" => 1, "two_for_one" => false },
                            { "intentional_draw" => false,
+                             "is_single_sided_swiss" => false,
                              "player1" => player_with_no_ids("Alice (she/her)"),
                              "player2" => bye_player,
                              "policy" => { "view_decks" => false },
@@ -134,6 +140,7 @@ RSpec.describe RoundsController do
                          "number" => 1,
                          "pairings" => [
                            { "intentional_draw" => false,
+                             "is_single_sided_swiss" => false,
                              "player1" => player_with_no_ids("Bob (he/him)"),
                              "player2" => player_with_no_ids("Charlie (she/her)"),
                              "policy" => { "view_decks" => false },


### PR DESCRIPTION
This tidies up a bunch of things for SSS rounds.

* Keeps Corp players on the left and runners on the right.
* Tidies up the ID view to be appropriate to the side.
* Changes the scoring buttons for the 4 possible results from SSS.