### PR TITLE
Add a note for manual pairing on single sided rounds.

### DIFF
--- a/app/views/home/help.html.slim
+++ b/app/views/home/help.html.slim
@@ -108,6 +108,7 @@
   p You can "Uncomplete" a round if you erroneously marked it as complete. Remember, this will hide the round's results from the standings.
   p You can "Re-pair" the round. This will delete ALL pairings in this round (the result data for the round, if any, will be lost, so be careful!) and recalculate pairings again. This may be useful if you had to edit a misreported result from the previous round.
   p You can also use this page to manually edit the pairings. Delete the pairings that are incorrect by clicking the bin/trash button on that row. Then a list of "Unpaired players" will be displayed, and a "Create pairing" form will appear. You can create pairings with any unpaired players (including dropped players if necessary) and also byes.
+  p For Single-Sided rounds, you will need to set the sides for the players after making the pairing with the "Corp" and "Runner" buttons.
 
   hr.my-4
 

--- a/app/views/rounds/show.html.slim
+++ b/app/views/rounds/show.html.slim
@@ -29,6 +29,9 @@ h3.mt-2.col-12 Unpaired players
   - @round.unpaired_players.each do |player|
     = render player
   h3.mt-2.col-12 Create pairing
+  - if @round.stage.single_sided?
+    .mt-2.col-12 This is a round for a single-sided stage so you will need to set sides after creating pairings.
+    .mt-2.col-12
   = simple_form_for @round.pairings.build, url: tournament_round_pairings_path(@round.tournament, @round), html: { class: 'form-inline col-12' } do |f|
     = f.text_field :table_number, placeholder: 'Table number', class: 'form-control'
     = pairing_player_select(f, :player1_id, @round)


### PR DESCRIPTION
This adds some instruction for manual pairings during single sided rounds.

<img width="734" alt="Screenshot 2024-09-01 at 11 03 06 AM" src="https://github.com/user-attachments/assets/f5185225-f334-4a25-ae61-a656917872fe">
