### PR TITLE
Enable Single sided swiss in development mode.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,10 +69,7 @@ Rails.application.configure do
     Flipper.enable :nrdb_deck_registration
     Flipper.enable :open_list_cut
     Flipper.enable :streaming_opt_out
-    cool_users = User.where(nrdb_username: ['plural'])
-    cool_users.each do |user|
-      Flipper.enable_actor(:single_sided_swiss, user)
-    end
+    Flipper.enable :single_sided_swiss
   rescue StandardError => e
     Rails.logger.warn "Failed setting Flipper features: #{e.class}"
   end


### PR DESCRIPTION
i was learning how to do more specific enabling with flipper, but this should always be on in dev.