### PR TITLE
Remove config.action_dispatch.x_sendfile_header since we aren't using it.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
This removes a bunch of spurious warnings in the logs.

To use this we would need to change the nginx-proxy config to have filesystem access to the static files to serve, which is a bit of a TODO.  Better to stop the log spam for now.