### PR TITLE
added gsub for fancy quotes

### DIFF
--- a/app/services/nrtm_json.rb
+++ b/app/services/nrtm_json.rb
@@ -19,8 +19,8 @@ class NrtmJson
           id: standing.player.id,
           name: standing.name,
           rank: i + 1,
-          corpIdentity: (standing.corp_identity.name if standing.corp_identity.id),
-          runnerIdentity: (standing.runner_identity.name if standing.runner_identity.id),
+          corpIdentity: (standing.corp_identity.name.gsub(/[“”]/, '"') if standing.corp_identity.id),
+          runnerIdentity: (standing.runner_identity.name.gsub(/[“”]/, '"') if standing.runner_identity.id),
           matchPoints: standing.points,
           strengthOfSchedule: standing.sos,
           extendedStrengthOfSchedule: standing.extended_sos

--- a/spec/fixtures/files/nrtm_json_single_sided_fancy_quotes.json
+++ b/spec/fixtures/files/nrtm_json_single_sided_fancy_quotes.json
@@ -1,0 +1,43 @@
+{
+    "name": "Some Tournament",
+    "date": "2017-01-01",
+    "cutToTop": 0,
+    "preliminaryRounds": 1,
+    "tournamentOrganiser": {
+      "nrdbId": 123,
+      "nrdbUsername": "username"
+    },
+    "players": [
+      {
+        "id": 1009, "name": "Loup Fan 1000", "rank": 1, "corpIdentity": "PE",
+        "runnerIdentity": "René \"Loup\" Arcemont: Party Animal",
+        "matchPoints": 3, "strengthOfSchedule": 1.5, 
+        "extendedStrengthOfSchedule": 2.5
+      },
+      {
+        "id": 1008, "name": "Kit Fan 100", "rank": 2, "corpIdentity": "RP",
+        "runnerIdentity": "Rielle \"Kit\" Peddler: Transhuman",
+        "matchPoints": 0, "strengthOfSchedule": 1.6,
+        "extendedStrengthOfSchedule": 2.6
+      }
+    ],
+    "eliminationPlayers": [],
+    "rounds": [
+      [
+        {
+          "table": 1,
+          "player1": { "id": 1009, "role": "runner", "runnerScore": 3, "corpScore": null, "combinedScore": 3 },
+          "player2": { "id": 1008, "role": "corp", "runnerScore": null, "corpScore": 0, "combinedScore": 0 },
+          "intentionalDraw": false,
+          "twoForOne": false,
+          "eliminationGame": false
+        }
+      ]
+    ],
+    "uploadedFrom": "Cobra",
+    "links": [
+      { "rel": "schemaderivedfrom", "href": "http://steffens.org/nrtm/nrtm-schema.json" },
+      { "rel": "uploadedfrom", "href": "https://server/SLUG" }
+    ]
+  }
+  


### PR DESCRIPTION
Always Be Running doesn't like the fancy quotes we have for runners like Kit, Loup, Ken, etc. 

Rather than handle it everywhere, this PR just updates the quotes to be ABR friendly when doing the JSON export. 

I can't seem to get the ABR export option to work when testing live, so for now this is just a JSON fix. 

Small test case issue for later: the ordering of the single sided swiss tests here influences the pairing tests. Namely if the test I created runs after the original single sided swiss test, then the pairings test starts failing, but moving the quotes test earlier resolves that issue. 