### PR TITLE
Add confirmation dialog for player deletion in tournament view

### DIFF
--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -122,7 +122,7 @@
           =< link_to drop_tournament_player_path(@tournament, player), method: :patch, class: 'btn btn-link text-warning mr-2' do
             => fa_icon 'arrow-down'
             | Drop
-          =< link_to tournament_player_path(@tournament, player), method: :delete, class: 'btn btn-link text-danger mr-2', data: { confirm: 'Are you sure you want to delete this?' } do
+          =< link_to tournament_player_path(@tournament, player), method: :delete, class: 'btn btn-link text-danger mr-2', data: { confirm: "Are you sure you want to delete player \"#{player.name}\"?" } do
             => fa_icon 'trash'
             | Delete
 

--- a/app/views/players/index.html.slim
+++ b/app/views/players/index.html.slim
@@ -122,7 +122,7 @@
           =< link_to drop_tournament_player_path(@tournament, player), method: :patch, class: 'btn btn-link text-warning mr-2' do
             => fa_icon 'arrow-down'
             | Drop
-          =< link_to tournament_player_path(@tournament, player), method: :delete, class: 'btn btn-link text-danger mr-2' do
+          =< link_to tournament_player_path(@tournament, player), method: :delete, class: 'btn btn-link text-danger mr-2', data: { confirm: 'Are you sure you want to delete this?' } do
             => fa_icon 'trash'
             | Delete
 


### PR DESCRIPTION
#### Changes  
- Added `data: { confirm: 'Are you sure you want to delete this?' }` to the player delete link in the tournament view.  

#### Reason  
- Prevents accidental deletions by requiring confirmation.  

#### How to Test
1. Click the delete button for a player.  
2. A confirmation dialog appears.  
3. Click "OK" to delete, or "Cancel" to abort.

#384 