### PR TITLE
Make JSON available only after tournament registration is closed

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -32,8 +32,12 @@ class TournamentsController < ApplicationController
         set_overview_notices
       end
       format.json do
-        headers['Access-Control-Allow-Origin'] = '*'
-        render json: NrtmJson.new(@tournament).data(tournament_url(@tournament.slug, @request))
+        if @tournament.registration_closed
+          headers['Access-Control-Allow-Origin'] = '*'
+          render json: NrtmJson.new(@tournament).data(tournament_url(@tournament.slug, @request))
+        else
+          redirect_back_or_to tournament_path(@tournament)
+        end
       end
     end
   end


### PR DESCRIPTION
Tournament JSONs (and by extension, ID choices) are currently directly accessible for tournaments which have not started yet. This change adds a conditional to check if a tournament has closed its registration before rendering the JSON, otherwise redirecting to the tournament page.