### PR TITLE
no longer displays players if no rounds have begun

### DIFF
--- a/app/services/nrtm_json.rb
+++ b/app/services/nrtm_json.rb
@@ -13,18 +13,21 @@ class NrtmJson
     preliminaryRounds = 0
     players = []
     if swiss_stage
+      Rails.logger.debug swiss_stage
       preliminaryRounds = swiss_stage.rounds.count
-      players = swiss_stage.standings.each_with_index.map do |standing, i|
-        {
-          id: standing.player.id,
-          name: standing.name,
-          rank: i + 1,
-          corpIdentity: (standing.corp_identity.name.gsub(/[“”]/, '"') if standing.corp_identity.id),
-          runnerIdentity: (standing.runner_identity.name.gsub(/[“”]/, '"') if standing.runner_identity.id),
-          matchPoints: standing.points,
-          strengthOfSchedule: standing.sos,
-          extendedStrengthOfSchedule: standing.extended_sos
-        }
+      if preliminaryRounds.positive?
+        players = swiss_stage.standings.each_with_index.map do |standing, i|
+          {
+            id: standing.player.id,
+            name: standing.name,
+            rank: i + 1,
+            corpIdentity: (standing.corp_identity.name.gsub(/[“”]/, '"') if standing.corp_identity.id),
+            runnerIdentity: (standing.runner_identity.name.gsub(/[“”]/, '"') if standing.runner_identity.id),
+            matchPoints: standing.points,
+            strengthOfSchedule: standing.sos,
+            extendedStrengthOfSchedule: standing.extended_sos
+          }
+        end
       end
     end
 

--- a/app/services/nrtm_json.rb
+++ b/app/services/nrtm_json.rb
@@ -13,7 +13,6 @@ class NrtmJson
     preliminaryRounds = 0
     players = []
     if swiss_stage
-      Rails.logger.debug swiss_stage
       preliminaryRounds = swiss_stage.rounds.count
       if preliminaryRounds.positive?
         players = swiss_stage.standings.each_with_index.map do |standing, i|


### PR DESCRIPTION
Currently while a tournament has registration open and no rounds started, if there is a swiss stage, anyone can hit the `.json` endpoint to get information on which players have registered as well as their faction / identity selection prior to registering. This potentially allows for extra information to "read the meta"

Now if no rounds have begun, the exported json contains no information on the players. 