### PR TITLE
Add basic stats tab to tournaments with placeholder template.

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -5,7 +5,7 @@ class TournamentsController < ApplicationController
     show info edit update destroy
     upload_to_abr save_json cut qr registration timer
     close_registration open_registration lock_player_registrations unlock_player_registrations
-    id_and_faction_data cut_conversion_rates side_win_percentages
+    id_and_faction_data cut_conversion_rates side_win_percentages stats
   ]
 
   def index
@@ -31,6 +31,10 @@ class TournamentsController < ApplicationController
     authorize Tournament
 
     @tournaments = current_user.tournaments.includes(:tournament_type).order(date: :desc)
+  end
+
+  def stats
+    authorize @tournament, :show?
   end
 
   def show

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -77,6 +77,10 @@ html
             li.nav-item= link_to standings_tournament_players_path(@tournament), class: "nav-link #{'active' if controller_name == 'players' && action_name == 'standings'}" do
               => fa_icon 'list-ol'
               | Standings
+          - if policy(@tournament).show?
+            li.nav-item= link_to stats_tournament_path(@tournament), class: "nav-link #{'active' if controller_name == 'tournaments' && action_name == 'stats'}" do
+              => fa_icon 'pie-chart'
+              | Stats
           - if policy(@tournament).edit?
             li.nav-item= link_to edit_tournament_path(@tournament), class: "nav-link #{'active' if controller_name == 'tournaments' && action_name == 'edit'}" do
               => fa_icon 'cog'

--- a/app/views/tournaments/stats.html.slim
+++ b/app/views/tournaments/stats.html.slim
@@ -1,0 +1,6 @@
+.col-12
+  - if @tournament.rounds.any?
+    h3 Cool Stats Will Go Here
+  - else
+    h3 No Stats Available
+    p This tournament has no rounds yet. Stats will be available once the tournament has started and rounds have been played.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     get :shortlink, on: :collection
     get :not_found, on: :collection
     get :my, on: :collection
+    get :stats, on: :member
     get 'type/:type_id', to: 'tournaments#index', on: :collection, as: :tournaments_by_type
   end
   resources :identities, only: [:index]


### PR DESCRIPTION
Before stats are available

<img width="947" alt="Screenshot 2025-03-29 at 10 59 41 AM" src="https://github.com/user-attachments/assets/b9501f56-c319-4fb8-9a1a-2739a4d07984" />

After stats are available
<img width="883" alt="Screenshot 2025-03-29 at 10 59 33 AM" src="https://github.com/user-attachments/assets/4417dfd4-d27b-4625-ba42-4189bf255f80" />
