### PR TITLE
Add faction to identities struct in cut conversion rate data.

### DIFF
--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -294,6 +294,7 @@ class Tournament < ApplicationRecord
 
       # Identities are already unique, so just insert them into results.
       results[:identities][side][row['identity']] = {
+        faction: row['faction'],
         num_swiss_players: row['num_swiss_players'].to_i,
         num_cut_players: row['num_cut_players'].to_i,
         cut_conversion_percentage: row['cut_conversion_percentage'].to_f.floor(2)

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -406,16 +406,18 @@ RSpec.describe Tournament do
           },
           identities: {
             corp: {
-              'Epiphany' => { num_swiss_players: 1, num_cut_players: 0,
+              'Epiphany' => { faction: 'nbn', num_swiss_players: 1, num_cut_players: 0,
                               cut_conversion_percentage: 0.0 },
-              'Precision Design' => { num_swiss_players: 2, num_cut_players: 0,
+              'Precision Design' => { faction: 'haas-bioroid', num_swiss_players: 2, num_cut_players: 0,
                                       cut_conversion_percentage: 0.0 },
-              'Unspecified' => { num_swiss_players: 3, num_cut_players: 0, cut_conversion_percentage: 0.0 }
+              'Unspecified' => { faction: 'Unspecified', num_swiss_players: 3, num_cut_players: 0,
+                                 cut_conversion_percentage: 0.0 }
             },
             runner: {
-              'Unspecified' => { num_swiss_players: 3, num_cut_players: 0, cut_conversion_percentage: 0.0 },
-              'Maxx' => { num_swiss_players: 2, num_cut_players: 0, cut_conversion_percentage: 0.0 },
-              'Smoke' => { num_swiss_players: 1, num_cut_players: 0, cut_conversion_percentage: 0.0 }
+              'Unspecified' => { faction: 'Unspecified', num_swiss_players: 3, num_cut_players: 0,
+                                 cut_conversion_percentage: 0.0 },
+              'Maxx' => { faction: 'anarch', num_swiss_players: 2, num_cut_players: 0, cut_conversion_percentage: 0.0 },
+              'Smoke' => { faction: 'shaper', num_swiss_players: 1, num_cut_players: 0, cut_conversion_percentage: 0.0 }
             }
           }
         }
@@ -447,18 +449,20 @@ RSpec.describe Tournament do
           },
           identities: {
             corp: {
-              'Epiphany' => { num_swiss_players: 1, num_cut_players: 1,
+              'Epiphany' => { faction: 'nbn', num_swiss_players: 1, num_cut_players: 1,
                               cut_conversion_percentage: 100.0 },
-              'Precision Design' => { num_swiss_players: 2, num_cut_players: 2,
+              'Precision Design' => { faction: 'haas-bioroid', num_swiss_players: 2, num_cut_players: 2,
                                       cut_conversion_percentage: 100.0 },
-              'Unspecified' => { num_swiss_players: 3, num_cut_players: 1,
+              'Unspecified' => { faction: 'Unspecified', num_swiss_players: 3, num_cut_players: 1,
                                  cut_conversion_percentage: ((1 / 3.0) * 100).floor(2) }
             },
             runner: {
-              'Unspecified' => { num_swiss_players: 3, num_cut_players: 1,
+              'Unspecified' => { faction: 'Unspecified', num_swiss_players: 3, num_cut_players: 1,
                                  cut_conversion_percentage: ((1 / 3.0) * 100).floor(2) },
-              'Maxx' => { num_swiss_players: 2, num_cut_players: 2, cut_conversion_percentage: 100.0 },
-              'Smoke' => { num_swiss_players: 1, num_cut_players: 1, cut_conversion_percentage: 100.0 }
+              'Maxx' => { faction: 'anarch', num_swiss_players: 2, num_cut_players: 2,
+                          cut_conversion_percentage: 100.0 },
+              'Smoke' => { faction: 'shaper', num_swiss_players: 1, num_cut_players: 1,
+                           cut_conversion_percentage: 100.0 }
             }
           }
         }


### PR DESCRIPTION
Next bit of #410 

Ensure the data has factions for identities so we can do a pretty, consistent display.