### PR TITLE
Add a new tournament setting for self-reporting.

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -273,7 +273,7 @@ class TournamentsController < ApplicationController
                                        :time_zone, :registration_starts, :tournament_starts, :tournament_type_id,
                                        :card_set_id, :format_id, :deckbuilding_restriction_id, :decklist_required,
                                        :organizer_contact, :event_link, :description, :official_prize_kit_id,
-                                       :additional_prizes_description)
+                                       :additional_prizes_description, :allow_self_reporting)
   end
 
   def set_tournament_view_data

--- a/app/views/tournaments/_form.html.slim
+++ b/app/views/tournaments/_form.html.slim
@@ -61,6 +61,9 @@
 - if Flipper.enabled? :nrdb_deck_registration
   .form-group
     = f.input :nrdb_deck_registration, as: :boolean, inline_label: 'Deck registration: Upload decks from NetrunnerDB'
+- if Flipper.enabled? :allow_self_reporting
+  .form-group
+    = f.input :allow_self_reporting, as: :boolean, inline_label: 'Allow logged-in players to report their own match results'
 .form-group
   = f.input :private, as: :boolean, inline_label: 'Private: Only I will be able to view this tournament'
 .form-group

--- a/db/migrate/20250405034059_add_all_self_reporting_to_tournament.rb
+++ b/db/migrate/20250405034059_add_all_self_reporting_to_tournament.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllSelfReportingToTournament < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tournaments, :allow_self_reporting, :bool, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_08_193210) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_05_034059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -292,6 +292,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_08_193210) do
     t.bigint "official_prize_kit_id"
     t.string "card_set_id"
     t.string "time_zone"
+    t.boolean "allow_self_reporting", default: false
     t.index ["card_set_id"], name: "index_tournaments_on_card_set_id"
     t.index ["deckbuilding_restriction_id"], name: "index_tournaments_on_deckbuilding_restriction_id"
     t.index ["format_id"], name: "index_tournaments_on_format_id"


### PR DESCRIPTION
Step 1 of #457 

This setting is flag guarded.  This PR only adds the field to the DB and allows the form to set the setting if the flag is on.