### PR TITLE
use img-fluid class on images

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ require 'redcarpet'
 module ApplicationHelper
 
   class ResponsiveImgRenderer < Redcarpet::Render::HTML 
-    def image(link, _title, alt_text) 
+    def image(link, _title, alt_text)
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,10 +5,10 @@ require 'redcarpet'
 module ApplicationHelper
 
   class ResponsiveImgRenderer < Redcarpet::Render::HTML 
-    def image(link, title, alt_text) 
+    def image(link, _title, alt_text) 
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
-    end 
-  end 
+    end
+  end
 
   def markdown(text)
     options = {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,6 @@
 require 'redcarpet'
 
 module ApplicationHelper
-
   class ResponsiveImgRenderer < Redcarpet::Render::HTML
     def image(link, _title, alt_text)
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ require 'redcarpet'
 
 module ApplicationHelper
 
-  class ResponsiveImgRenderer < Redcarpet::Render::HTML 
+  class ResponsiveImgRenderer < Redcarpet::Render::HTML
     def image(link, _title, alt_text)
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,13 @@
 require 'redcarpet'
 
 module ApplicationHelper
+
+  class ResponsiveImgRenderer < Redcarpet::Render::HTML 
+    def image(link, title, alt_text) 
+      %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
+    end 
+  end 
+
   def markdown(text)
     options = {
       filter_html: true,
@@ -12,7 +19,7 @@ module ApplicationHelper
       fenced_code_blocks: true
     }
 
-    renderer = Redcarpet::Render::HTML.new(options)
+    renderer = ResponsiveImgRenderer.new(options)
     markdown = Redcarpet::Markdown.new(renderer)
 
     markdown.render(text).html_safe # rubocop:disable Rails/OutputSafety


### PR DESCRIPTION
https://tournaments.nullsignal.games/tournaments/3919/info

Images in markdown are able to overflow out of parent containers

Bootstrap offers responsive images via img-fluid, so I created a custom renderer that adds that class to each img in the markdown field. 

https://getbootstrap.com/docs/4.0/content/images/#responsive-images