### PR TITLE
Normalize scores if a side is set for a pairing.

### DIFF
--- a/app/models/pairing.rb
+++ b/app/models/pairing.rb
@@ -132,6 +132,7 @@ class Pairing < ApplicationRecord
     ensure_custom_scores_complete
   end
 
+
   def combine_separate_side_scores
     return unless (score1_corp.present? && score1_corp.positive?) ||
                   (score1_runner.present? && score1_runner.positive?) ||
@@ -147,5 +148,18 @@ class Pairing < ApplicationRecord
 
     self.score1 = score1 || 0
     self.score2 = score2 || 0
+
+    # If a side is set, ensure that the scores for the sides are set properly.
+    if side == 'player1_is_corp'
+      self.score1_corp = score1
+      self.score1_runner = 0
+      self.score2_corp = 0
+      self.score2_runner = score2
+    elsif side == 'player1_is_runner'
+      self.score1_corp = 0
+      self.score1_runner = score1
+      self.score2_corp = score2
+      self.score2_runner = 0
+    end
   end
 end

--- a/spec/feature/pairings/report_pairings_spec.rb
+++ b/spec/feature/pairings/report_pairings_spec.rb
@@ -171,26 +171,25 @@ RSpec.describe 'reporting scores for pairings' do
     end
   end
 
-  describe 'custom scores' do
-    # Scores only show up after sides are selected.
+
+  describe 'custom score form behaves when side is not set' do
     before do
-      pairing.update(side: :player1_is_corp)
       visit tournament_rounds_path(tournament)
     end
 
     it 'stores score' do
       all(:link, '...')[0].click
-      fill_in :pairing_score1, with: '4'
-      fill_in :pairing_score2, with: '1'
+      fill_in :pairing_score1, with: '3'
+      fill_in :pairing_score2, with: '0'
       click_button 'Save'
 
       pairing.reload
 
       aggregate_failures do
-        expect(pairing.score1).to eq(4)
+        expect(pairing.score1).to eq(3)
         expect(pairing.score1_corp).to eq(0)
         expect(pairing.score1_runner).to eq(0)
-        expect(pairing.score2).to eq(1)
+        expect(pairing.score2).to eq(0)
         expect(pairing.score2_corp).to eq(0)
         expect(pairing.score2_runner).to eq(0)
       end
@@ -200,14 +199,14 @@ RSpec.describe 'reporting scores for pairings' do
       pairing.update(score1_runner: 3)
 
       visit tournament_rounds_path(tournament)
-      fill_in :pairing_score1, with: '4'
+      fill_in :pairing_score1, with: '1'
       fill_in :pairing_score2, with: '1'
       click_button 'Save'
 
       pairing.reload
 
       aggregate_failures do
-        expect(pairing.score1).to eq(4)
+        expect(pairing.score1).to eq(1)
         expect(pairing.score1_corp).to eq(0)
         expect(pairing.score1_runner).to eq(0)
         expect(pairing.score2).to eq(1)
@@ -217,17 +216,143 @@ RSpec.describe 'reporting scores for pairings' do
     end
 
     it 'stores a missing score as zero' do
-      fill_in :pairing_score1, with: '6'
+      fill_in :pairing_score1, with: '3'
       click_button 'Save'
 
       pairing.reload
 
       aggregate_failures do
-        expect(pairing.score1).to eq(6)
+        expect(pairing.score1).to eq(3)
         expect(pairing.score1_corp).to eq(0)
         expect(pairing.score1_runner).to eq(0)
         expect(pairing.score2).to eq(0)
         expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(0)
+      end
+    end
+  end
+
+  describe 'custom score form sets side scores appropriately when player1 is corp' do
+    before do
+      stage.update(format: :single_sided_swiss)
+      pairing.update(side: :player1_is_corp)
+      visit tournament_rounds_path(tournament)
+    end
+
+    it 'sets side scores appropriately' do
+      all(:link, '...')[0].click
+      fill_in :pairing_score1, with: '3'
+      fill_in :pairing_score2, with: '0'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(3)
+        expect(pairing.score1_corp).to eq(3)
+        expect(pairing.score1_runner).to eq(0)
+        expect(pairing.score2).to eq(0)
+        expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(0)
+      end
+    end
+
+    it 'blanks pre-existing side scores' do
+      pairing.update(score1_runner: 3)
+
+      visit tournament_rounds_path(tournament)
+      fill_in :pairing_score1, with: '3'
+      fill_in :pairing_score2, with: '0'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(3)
+        expect(pairing.score1_corp).to eq(3)
+        expect(pairing.score1_runner).to eq(0)
+        expect(pairing.score2).to eq(0)
+        expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(0)
+      end
+    end
+
+    it 'sets both players scores appropriately' do
+      fill_in :pairing_score1, with: '1'
+      fill_in :pairing_score2, with: '1'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(1)
+        expect(pairing.score1_corp).to eq(1)
+        expect(pairing.score1_runner).to eq(0)
+        expect(pairing.score2).to eq(1)
+        expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(1)
+      end
+    end
+  end
+
+  describe 'custom score form sets side scores appropriately when player1 is runner' do
+    before do
+      stage.update(format: :single_sided_swiss)
+      pairing.update(side: :player1_is_runner)
+      visit tournament_rounds_path(tournament)
+    end
+
+    it 'sets side scores appropriately' do
+      all(:link, '...')[0].click
+      fill_in :pairing_score1, with: '3'
+      fill_in :pairing_score2, with: '0'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(3)
+        expect(pairing.score1_corp).to eq(0)
+        expect(pairing.score1_runner).to eq(3)
+        expect(pairing.score2).to eq(0)
+        expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(0)
+      end
+    end
+
+    it 'blanks pre-existing side scores' do
+      pairing.update(score1_corp: 3)
+
+      visit tournament_rounds_path(tournament)
+      fill_in :pairing_score1, with: '3'
+      fill_in :pairing_score2, with: '0'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(3)
+        expect(pairing.score1_corp).to eq(0)
+        expect(pairing.score1_runner).to eq(3)
+        expect(pairing.score2).to eq(0)
+        expect(pairing.score2_corp).to eq(0)
+        expect(pairing.score2_runner).to eq(0)
+      end
+    end
+
+    it 'sets both players scores appropriately' do
+      fill_in :pairing_score1, with: '1'
+      fill_in :pairing_score2, with: '1'
+      click_button 'Save'
+
+      pairing.reload
+
+      aggregate_failures do
+        expect(pairing.score1).to eq(1)
+        expect(pairing.score1_corp).to eq(0)
+        expect(pairing.score1_runner).to eq(1)
+        expect(pairing.score2).to eq(1)
+        expect(pairing.score2_corp).to eq(1)
         expect(pairing.score2_runner).to eq(0)
       end
     end


### PR DESCRIPTION
Fixes #481 

This updates the pre-save hook for pairing to use the side to set the side specific scores if the generic side fields are set.