### PR TITLE
Don't show side setting buttons for byes.

### DIFF
--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -36,7 +36,8 @@
     .col-sm.left_player_name
       = left_player.name_with_pronouns
       <br />
-      =< render 'player_side', pairing: pairing, player: left_player, single_sided: single_sided
+      - unless pairing.bye?
+        =< render 'player_side', pairing: pairing, player: left_player, single_sided: single_sided
       - if left_player.id
         .ids
           - if round.stage.single_sided?
@@ -89,7 +90,8 @@
     .col-sm.right_player_name
       = right_player.name_with_pronouns
       <br />
-      =< render 'player_side', pairing: pairing, player: right_player, single_sided: single_sided
+      - unless pairing.bye?
+        =< render 'player_side', pairing: pairing, player: right_player, single_sided: single_sided
       - if right_player.id
         .ids
           - if round.stage.single_sided?


### PR DESCRIPTION
We don't need the buttons on byes and we don't want to accidentally allow people to set sides for the real player in a bye.

<img width="1142" alt="Screenshot 2025-06-24 at 9 51 09 AM" src="https://github.com/user-attachments/assets/1753306f-b92c-4bca-820c-3fe1088c39cb" />
