### PR TITLE
Show byes on standings

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -186,6 +186,7 @@ class PlayersController < ApplicationController
         extended_sos: row.extended_sos,
         corp_points: row.corp_points || 0,
         runner_points: row.runner_points || 0,
+        bye_points: row.bye_points || 0,
         manual_seed: row.manual_seed,
         side_bias: stage.format == 'single_sided_swiss' ? row.player.side_bias : nil
       }

--- a/app/frontend/standings/StandingsData.ts
+++ b/app/frontend/standings/StandingsData.ts
@@ -42,6 +42,7 @@ export interface SwissStanding {
   points: number;
   sos: string;
   extended_sos: string;
+  bye_points: number;
   corp_points: number;
   runner_points: number;
   manual_seed: number | null;

--- a/app/frontend/standings/SwissStandings.svelte
+++ b/app/frontend/standings/SwissStandings.svelte
@@ -75,12 +75,12 @@
             points={standing.runner_points}
             name_if_missing="Runner"
           />
+          {#if standing.bye_points > 0}
+            &nbsp;Bye ({standing.bye_points})
+          {/if}
         </td>
         <td>
           {standing.points}
-          {#if standing.bye_points > 0}
-            ({standing.bye_points} bye)
-          {/if}
         </td>
         {#if manual_seed}
           <td>{standing.manual_seed}</td>

--- a/app/frontend/standings/SwissStandings.svelte
+++ b/app/frontend/standings/SwissStandings.svelte
@@ -76,7 +76,12 @@
             name_if_missing="Runner"
           />
         </td>
-        <td>{standing.points}</td>
+        <td>
+          {standing.points}
+          {#if standing.bye_points > 0}
+            ({standing.bye_points} bye)
+          {/if}
+        </td>
         {#if manual_seed}
           <td>{standing.manual_seed}</td>
         {/if}

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -60,7 +60,8 @@ class Stage < ApplicationRecord
         sos: standing.sos,
         extended_sos: standing.extended_sos,
         corp_points: standing.corp_points,
-        runner_points: standing.runner_points
+        runner_points: standing.runner_points,
+        bye_points: standing.bye_points || 0
       )
     end
   end

--- a/app/services/sos_calculator.rb
+++ b/app/services/sos_calculator.rb
@@ -9,6 +9,7 @@ class SosCalculator
     games_played = {}
     opponents = {}
     points_for_sos = {}
+    bye_points = {}
     corp_points = {}
     runner_points = {}
     stage.eligible_pairings.each do |p|
@@ -36,6 +37,10 @@ class SosCalculator
       runner_points[p.player1_id] += p.score1_runner || 0
       runner_points[p.player2_id] ||= 0
       runner_points[p.player2_id] += p.score2_runner || 0
+      bye_points[p.player1_id] ||= 0
+      bye_points[p.player1_id] += p.score1 if p.player2_id.nil? && !p.score1.nil?
+      bye_points[p.player2_id] ||= 0
+      bye_points[p.player2_id] += p.score2 if p.player1_id.nil? && !p.score2.nil?
     end
 
     # filter out byes from sos calculations
@@ -70,6 +75,7 @@ class SosCalculator
                    points: points[p.id],
                    sos: sos[p.id],
                    extended_sos: extended_sos[p.id],
+                   bye_points: bye_points[p.id] || 0,
                    corp_points: corp_points[p.id],
                    runner_points: runner_points[p.id])
     end.sort

--- a/app/services/standing.rb
+++ b/app/services/standing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Standing
-  attr_reader :player, :points, :sos, :extended_sos, :corp_points, :runner_points
+  attr_reader :player, :points, :sos, :extended_sos, :bye_points, :corp_points, :runner_points
 
   delegate :name, :pronouns, :name_with_pronouns, to: :player
   delegate :tournament, :seed_in_stage, to: :player
@@ -11,6 +11,7 @@ class Standing
     @points = values.fetch(:points, 0) || 0
     @sos = values.fetch(:sos, 0) || 0
     @extended_sos = values.fetch(:extended_sos, 0) || 0
+    @bye_points = values.fetch(:bye_points, 0) || 0
     @corp_points = values.fetch(:corp_points, 0) || 0
     @runner_points = values.fetch(:runner_points, 0) || 0
   end

--- a/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
+++ b/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 class AddByePointsToStandingRows < ActiveRecord::Migration[7.2]
-  def change
+  def up
     add_column :standing_rows, :bye_points, :integer, default: 0
+    connection.exec_update <<-SQL
+      UPDATE standing_rows
+      SET bye_points = points - (corp_points + runner_points)
+      WHERE points <> (corp_points + runner_points)
+    SQL
+  end
+
+  def down
+    remove_column :standing_rows, :bye_points
   end
 end

--- a/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
+++ b/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddByePointsToStandingRows < ActiveRecord::Migration[7.2]
+  def change
+    add_column :standing_rows, :bye_points, :integer, default: 0
+  end
+end

--- a/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
+++ b/db/migrate/20250706040934_add_bye_points_to_standing_rows.rb
@@ -3,10 +3,29 @@
 class AddByePointsToStandingRows < ActiveRecord::Migration[7.2]
   def up
     add_column :standing_rows, :bye_points, :integer, default: 0
+
+    # This SQL is complicated because tournaments with cuts will have players listed in multiple stages.
+    # We need to limit the update only to stages with byes for each player.
     connection.exec_update <<-SQL
-      UPDATE standing_rows
-      SET bye_points = points - (corp_points + runner_points)
-      WHERE points <> (corp_points + runner_points)
+      UPDATE
+        standing_rows sr
+        SET bye_points = b.bye_points
+      FROM (
+        SELECT s.id as stage_id,
+          s.number as stage_number,
+          COALESCE(p.player1_id, p.player2_id) AS player_id,
+          COALESCE(p.score1, p.score2) AS bye_points
+        FROM pairings p
+          INNER JOIN rounds r ON p.round_id = r.id
+          INNER JOIN stages s ON r.stage_id = s.id
+        WHERE
+          (p.player1_id IS NULL OR p.player2_id IS NULL)
+          AND
+          (p.score1 > 0 OR p.score2 > 0)
+      ) b
+      WHERE
+        sr.player_id = b.player_id
+        AND sr.stage_id = b.stage_id;
     SQL
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_20_072144) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_06_040934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -276,6 +276,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_20_072144) do
     t.decimal "extended_sos"
     t.integer "corp_points"
     t.integer "runner_points"
+    t.integer "bye_points", default: 0
     t.index ["player_id"], name: "index_standing_rows_on_player_id"
     t.index ["stage_id"], name: "index_standing_rows_on_stage_id"
   end

--- a/spec/requests/players_controller_spec.rb
+++ b/spec/requests/players_controller_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe PlayersController do
                 'standings' => [
                   standing_with_custom_score(1, points: 6, sos: '0.0', extended_sos: '6.0',
                                                 player: player_with_no_ids('Charlie (she/her)')),
-                  standing_with_custom_score(2, points: 6, sos: '0.0', extended_sos: '0.0',
+                  standing_with_custom_score(2, points: 6, bye_points: 6, sos: '0.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Alice (she/her)')),
                   standing_with_custom_score(3, points: 0, sos: '6.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Bob (he/him)'))
@@ -481,7 +481,7 @@ RSpec.describe PlayersController do
                 'standings' => [
                   standing_with_custom_score(1, points: 6, sos: '0.0', extended_sos: '6.0',
                                                 player: player_with_no_ids('Charlie (she/her)')),
-                  standing_with_custom_score(2, points: 6, sos: '0.0', extended_sos: '0.0',
+                  standing_with_custom_score(2, points: 6, bye_points: 6, sos: '0.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Alice (she/her)')),
                   standing_with_custom_score(3, points: 0, sos: '6.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Bob (he/him)'))
@@ -532,7 +532,7 @@ RSpec.describe PlayersController do
                 'standings' => [
                   standing_with_custom_score(1, points: 6, sos: '0.0', extended_sos: '6.0',
                                                 player: player_with_no_ids('Charlie (she/her)')),
-                  standing_with_custom_score(2, points: 6, sos: '0.0', extended_sos: '0.0',
+                  standing_with_custom_score(2, points: 6, bye_points: 6, sos: '0.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Alice (she/her)')),
                   standing_with_custom_score(3, points: 0, sos: '6.0', extended_sos: '0.0',
                                                 player: player_with_no_ids('Bob (he/him)'))
@@ -568,7 +568,7 @@ RSpec.describe PlayersController do
     }
   end
 
-  def standing_with_custom_score(position, points:, sos:, extended_sos:, player:)
+  def standing_with_custom_score(position, points:, sos:, extended_sos:, player:, bye_points: 0) # rubocop:disable Metrics/ParameterLists
     {
       'position' => position,
       'player' => player,
@@ -576,8 +576,9 @@ RSpec.describe PlayersController do
       'points' => points,
       'sos' => sos,
       'extended_sos' => extended_sos,
-      'runner_points' => 0,
+      'bye_points' => bye_points,
       'corp_points' => 0,
+      'runner_points' => 0,
       'manual_seed' => nil,
       'side_bias' => nil
     }


### PR DESCRIPTION
Explicitly calculate bye points in standing and display them on the standings page.

Prior to this bye points were not shown leading to occasional questions.

<img width="1144" alt="Screenshot 2025-07-06 at 5 10 24 PM" src="https://github.com/user-attachments/assets/16bc323e-a8c4-43b2-809c-e744cf7334bf" />
