### PR TITLE
Adjust new tournament form JSON path

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -85,15 +85,14 @@ class TournamentsController < ApplicationController
 
   def new
     authorize Tournament
+  end
+
+  def new_form
+    authorize Tournament
 
     @new_tournament = current_user.tournaments.new
     @new_tournament.date = Date.current
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: helpers.tournament_settings_json(@new_tournament), status: :ok
-      end
-    end
+    render json: helpers.tournament_settings_json(@new_tournament), status: :ok
   end
 
   def create

--- a/app/frontend/msw/routes.ts
+++ b/app/frontend/msw/routes.ts
@@ -7,7 +7,7 @@
 
 const basePath = "https://localhost:3000";
 
-export function new_tournament_path() {
+export function new_form_tournaments_path() {
   return `${basePath}/tournaments/new`;
 }
 
@@ -17,7 +17,7 @@ export function tournaments_path() {
 
 Object.defineProperty(global, "Routes", {
   value: {
-    new_tournament_path,
+    new_form_tournaments_path,
     tournaments_path,
   },
 });

--- a/app/frontend/tournaments/TournamentSettings.msw-test.ts
+++ b/app/frontend/tournaments/TournamentSettings.msw-test.ts
@@ -7,7 +7,7 @@ import {
   emptyTournamentOptions,
 } from "./TournamentSettings";
 import { server } from "../msw/server";
-import { new_tournament_path, tournaments_path } from "../msw/routes";
+import { new_form_tournaments_path, tournaments_path } from "../msw/routes";
 
 describe("TournamentSettings", () => {
   describe("loadNewTournament", () => {
@@ -19,7 +19,7 @@ describe("TournamentSettings", () => {
       };
 
       server.use(
-        http.get(new_tournament_path(), ({ request }) => {
+        http.get(new_form_tournaments_path(), ({ request }) => {
           expect(request.headers.get("Accept")).toBe("application/json");
           return HttpResponse.json(mockData);
         }),
@@ -31,7 +31,7 @@ describe("TournamentSettings", () => {
 
     it("handles network errors", async () => {
       server.use(
-        http.get(new_tournament_path(), () => {
+        http.get(new_form_tournaments_path(), () => {
           return HttpResponse.error();
         }),
       );

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -1,7 +1,7 @@
 export type Errors = Record<string, string[]>;
 
 declare const Routes: {
-  new_tournament_path: () => string;
+  new_form_tournaments_path: () => string;
   tournaments_path: () => string;
 };
 
@@ -69,7 +69,7 @@ export function emptyTournamentOptions(): TournamentOptions {
 }
 
 export async function loadNewTournament(): Promise<TournamentSettingsData> {
-  const response = await fetch(Routes.new_tournament_path(), {
+  const response = await fetch(Routes.new_form_tournaments_path(), {
     headers: { Accept: "application/json" },
     method: "GET",
   });

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -24,6 +24,10 @@ class ApplicationPolicy
     create?
   end
 
+  def new_form?
+    new?
+  end
+
   def update?
     false
   end

--- a/app/policies/tournament_policy.rb
+++ b/app/policies/tournament_policy.rb
@@ -36,4 +36,8 @@ class TournamentPolicy < ApplicationPolicy
   def my?
     user
   end
+
+  def new_form?
+    user
+  end
 end

--- a/app/policies/tournament_policy.rb
+++ b/app/policies/tournament_policy.rb
@@ -36,8 +36,4 @@ class TournamentPolicy < ApplicationPolicy
   def my?
     user
   end
-
-  def new_form?
-    user
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     get :shortlink, on: :collection
     get :not_found, on: :collection
     get :my, on: :collection
+    get :new_form, on: :collection
     get :stats, on: :member
     get 'type/:type_id', to: 'tournaments#index', on: :collection, as: :tournaments_by_type
   end

--- a/spec/requests/tournaments_controller_new_form_spec.rb
+++ b/spec/requests/tournaments_controller_new_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TournamentsController, type: :request do
         restriction = create(:deckbuilding_restriction, name: 'Standard Ban List')
         prize_kit = create(:official_prize_kit, name: '2025 Q1 Game Night Kit', position: 1)
         travel_to Date.new(2023, 5, 15) do
-          get new_tournament_path, as: :json
+          get new_form_tournaments_path, as: :json
         end
 
         expect(response).to be_successful
@@ -73,7 +73,7 @@ RSpec.describe TournamentsController, type: :request do
       end
 
       it 'returns unauthorized status' do
-        get new_tournament_path, as: :json
+        get new_form_tournaments_path, as: :json
 
         expect(response).to have_http_status(:unauthorized)
       end


### PR DESCRIPTION
I changed this because of some very odd behaviour where it looked as though the browser was caching the HTML version of the endpoint and returning that from a request for the JSON version.