### PR TITLE
Separate out edit_form tournament endpoint

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -2,7 +2,7 @@
 
 class TournamentsController < ApplicationController
   before_action :set_tournament, only: %i[
-    show info edit update destroy
+    show info edit edit_form update destroy
     upload_to_abr save_json cut qr registration timer
     close_registration open_registration lock_player_registrations unlock_player_registrations
     id_and_faction_data cut_conversion_rates side_win_percentages stats
@@ -131,13 +131,11 @@ class TournamentsController < ApplicationController
 
   def edit
     authorize @tournament
+  end
 
-    respond_to do |format|
-      format.html
-      format.json do
-        render json: helpers.tournament_settings_json(@tournament)
-      end
-    end
+  def edit_form
+    authorize @tournament
+    render json: helpers.tournament_settings_json(@tournament)
   end
 
   def update

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -36,6 +36,10 @@ class ApplicationPolicy
     update?
   end
 
+  def edit_form?
+    edit?
+  end
+
   def destroy?
     false
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     get :not_found, on: :collection
     get :my, on: :collection
     get :new_form, on: :collection
+    get :edit_form, on: :member
     get :stats, on: :member
     get 'type/:type_id', to: 'tournaments#index', on: :collection, as: :tournaments_by_type
   end

--- a/spec/requests/tournaments_controller_edit_form_spec.rb
+++ b/spec/requests/tournaments_controller_edit_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TournamentsController, type: :request do
       end
 
       it 'returns tournament data' do
-        get edit_tournament_path(tournament), as: :json
+        get edit_form_tournament_path(tournament), as: :json
 
         expect(response).to be_successful
         expect(response.content_type).to include('application/json')
@@ -64,7 +64,7 @@ RSpec.describe TournamentsController, type: :request do
         restriction = create(:deckbuilding_restriction, name: 'Standard Ban List')
         prize_kit = create(:official_prize_kit, name: '2025 Q1 Game Night Kit', position: 1)
 
-        get edit_tournament_path(tournament), as: :json
+        get edit_form_tournament_path(tournament), as: :json
 
         data = JSON.parse(response.body)
         expect(data['options'].except('time_zones')).to eq(
@@ -106,7 +106,7 @@ RSpec.describe TournamentsController, type: :request do
       end
 
       it 'returns unauthorized status' do
-        get edit_tournament_path(tournament), as: :json
+        get edit_form_tournament_path(tournament), as: :json
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -118,7 +118,7 @@ RSpec.describe TournamentsController, type: :request do
       end
 
       it 'returns unauthorized status' do
-        get edit_tournament_path(tournament), as: :json
+        get edit_form_tournament_path(tournament), as: :json
 
         expect(response).to have_http_status(:unauthorized)
       end


### PR DESCRIPTION
This is to match the new tournament form, as done here:
- https://github.com/Project-NISEI/cobra/pull/510

This will be used for client side rendering in a follow up PR.