### PR TITLE
Switch to Aesop's Logic

### DIFF
--- a/spec/services/pairing_strategies/single_sided_swiss_spec.rb
+++ b/spec/services/pairing_strategies/single_sided_swiss_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe PairingStrategies::SingleSidedSwiss do
-  let(:pairer) { described_class.new(round) }
+  let(:pairer) { described_class.new(round, Random.new(1234)) }
   let(:round) { create(:round, number: 1, tournament:, stage:) }
   let(:stage) { tournament.current_stage }
   let(:tournament) { create(:tournament, swiss_format: :single_sided) }
@@ -26,8 +26,8 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
         create(:pairing, player1:, score1: 3, score2: 0)
       end
 
-      it 'returns a negative number' do
-        expect(described_class.points_weight(player1.points, player2.points)).to eq(-1.5)
+      it 'returns a small number' do
+        expect(described_class.points_weight(player1.points, player2.points)).to eq(9)
       end
     end
 
@@ -38,8 +38,8 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
         create(:pairing, player1:, score1: 0, score2: 3)
       end
 
-      it 'returns a more negative number' do
-        expect(described_class.points_weight(player1.points, player2.points)).to eq(-6)
+      it 'returns a slightly bigger small number' do
+        expect(described_class.points_weight(player1.points, player2.points)).to eq(36)
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
       end
 
       it 'returns 0' do
-        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(1)
+        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(50)
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
       end
 
       it 'returns positive number' do
-        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(8)
+        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(50)
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
       end
 
       it 'returns more positive number' do
-        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(64)
+        expect(described_class.side_bias_weight(player1.side_bias, player2.side_bias)).to eq(2500)
       end
     end
   end
@@ -106,12 +106,12 @@ RSpec.describe PairingStrategies::SingleSidedSwiss do
     let(:player1) { create(:player) }
     let(:player2) { create(:player) }
 
-    it 'returns 0 with no games played' do
+    it 'returns no penalty with no previous matchup' do
       expect(described_class.rematch_bias_weight(false)).to eq(0)
     end
 
-    it 'returns small negative number with 1 game played' do
-      expect(described_class.rematch_bias_weight(true)).to eq(-0.5)
+    it 'returns a penalty for a rematch' do
+      expect(described_class.rematch_bias_weight(true)).to eq(5)
     end
   end
 

--- a/spec/tournament_simulator.rb
+++ b/spec/tournament_simulator.rb
@@ -9,7 +9,6 @@ require 'stackprof'
 # to control the simulation.
 #
 # The following environment variables can be set to control the simulation:
-#     AESOPS_LOGIC - If set to '1' or 'true', uses the Aesops pairing logic, defaults to false.
 #     DROPS_PER_ROUND -  The number of players that drop out of the tournament each round, defaults to 0
 #     DSS_BOTH_TIE - The number of times both games in double-sided swiss end in a tie, defaults to 1.
 #     DSS_P1_SWEEPS - The number of times player 1 sweeps in double-sided swiss, defaults to 25.
@@ -137,7 +136,6 @@ RSpec.describe 'load testing' do
   let(:summary_results) do
     {
       swiss_format:,
-      aesops_logic: ENV['AESOPS_LOGIC'] ? true : false,
       num_players:,
       num_rounds:,
       num_drops_per_round:,
@@ -382,7 +380,6 @@ RSpec.describe 'load testing' do
   it 'can handle load' do
     puts 'Starting simulation with config:'
     puts "  swiss_format:                    #{swiss_format}"
-    puts "  aesops_logic:                    #{ENV['AESOPS_LOGIC'] ? 'true' : 'false'}"
     puts "  num_players:                     #{num_players}"
     puts "  num_rounds:                      #{num_rounds}"
     puts "  num_drops_per_round:             #{num_drops_per_round}"


### PR DESCRIPTION
Fixes #521 

Tournament simulations show this bringing the number of bye vs bye pairings down to expected levels compared to UK nats (2-10 vs. nearly 13% of matchups at UK nats).
