### PR TITLE
Replace (dropped) with tooltip icon

### DIFF
--- a/app/frontend/standings/SwissStandings.svelte
+++ b/app/frontend/standings/SwissStandings.svelte
@@ -2,6 +2,7 @@
   import type { SwissStage } from "./StandingsData";
   import Identity from "../identities/Identity.svelte";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+  import Tooltip from "./Tooltip.svelte";
 
   export let stage: SwissStage;
   export let manual_seed: boolean;
@@ -50,9 +51,13 @@
     {#each stage.standings as standing (standing.position)}
       <tr>
         <td>{standing.position}</td>
-        <td>
-          {standing.player.name_with_pronouns}
-          {standing.player.active ? "" : "(dropped)"}
+        <td class="d-flex flex-row space-x-2">
+          <p class="mr-2">{standing.player.name_with_pronouns}</p>
+          {#if !standing.player.active}
+            <Tooltip text="(dropped)">
+              <FontAwesomeIcon icon="sign-out" />
+            </Tooltip>
+          {/if}
         </td>
         {#if stage.any_decks_viewable}
           <td>

--- a/app/frontend/standings/Tooltip.svelte
+++ b/app/frontend/standings/Tooltip.svelte
@@ -1,0 +1,23 @@
+<!-- TODO: Replace with library or move when used more often. Currently no need for a lib-->
+
+<script>
+  export let text = "";
+
+  let isHovered = false;
+</script>
+
+<div
+  class="position-relative"
+  on:mouseenter={() => (isHovered = true)}
+  on:mouseleave={() => (isHovered = false)}
+>
+  <slot />
+  {#if isHovered}
+    <div
+      class="position-absolute bg-dark text-white p-1 rounded text-nowrap mb-1"
+      style="bottom: 100%; left: 50%; transform: translateX(-50%); z-index: 1000;"
+    >
+      {text}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
In the standings page, dropped players where marked with a text as (dropped) resulting in long player cell which could be confusing with pronouns eg. TrueSvenpai (he/him) (dropepd).
Now dropped players are marked with fa-sign-out icon with a tooltip saying (dropped)

<img width="1154" height="271" alt="Screenshot 2025-07-13 at 13 29 41" src="https://github.com/user-attachments/assets/8db3c8fe-dc50-4aaf-80d5-add6d8bbf66c" />
<img width="1195" height="273" alt="Screenshot 2025-07-13 at 13 29 51" src="https://github.com/user-attachments/assets/aa60e7d0-c65d-486c-bbfc-dc16d1b60232" />
