### PR TITLE
Add readable self report scores

### DIFF
--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -153,6 +153,30 @@ module PairingsHelper
     end
   end
 
+  # TODO: (TrueSvenpai): refactor to reduce code duplication.
+  def readable_self_report_score(pairing, self_report)
+    return '-' if self_report.score1&.zero? && self_report.score2&.zero?
+
+    ws = winning_side(self_report)
+
+    if pairing.stage.single_sided_swiss?
+      if pairing.player1_is_corp? || pairing.side.nil?
+        left_score = self_report.score1
+        right_score = self_report.score2
+      else
+        left_score = self_report.score2
+        right_score = self_report.score1
+      end
+      return "#{left_score} - #{right_score}" unless ws
+
+      "#{left_score} - #{right_score} (#{ws})"
+    else
+      return "#{self_report.score1} - #{self_report.score2}" unless ws
+
+      "#{self_report.score1} - #{self_report.score2} (#{ws})"
+    end
+  end
+
   def winning_side(pairing)
     corp_score = (pairing.score1_corp || 0) + (pairing.score2_corp || 0)
     runner_score = (pairing.score1_runner || 0) + (pairing.score2_runner || 0)

--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -16,7 +16,7 @@
   - left_player_report = pairing.self_reports.find { |report| report.report_player_id == left_player.user_id }
   - right_player_report = pairing.self_reports.find { |report| report.report_player_id == right_player.user_id }
   - players_have_self_reported = (right_player_report != nil && left_player_report != nil)
-  - self_reports_match = ((right_player_report&.score1 == left_player_report&.score1) || (right_player_report&.score2 == left_player_report&.score2))
+  - self_reports_match = ((right_player_report&.score1 == left_player_report&.score1) && (right_player_report&.score2 == left_player_report&.score2) && (right_player_report&.score1_corp == left_player_report&.score1_corp) && (right_player_report&.score2_corp == left_player_report&.score2_corp) && (right_player_report&.score1_runner == left_player_report&.score1_runner) && (right_player_report&.score2_runner == left_player_report&.score2_runner))
 
   .row.m-1.round_pairing.align-items-center class="table_#{pairing.table_number} #{'reported' if pairing.reported? && current_user == @tournament.user} #{'self_reports_match' if !pairing.reported? && players_have_self_reported && !self_reports_match}"
     .col-sm-2
@@ -47,7 +47,7 @@
         | View decks
     .col-sm.left_player_name
       = left_player.name_with_pronouns
-      = render 'self_report_icon', player_report: left_player_report, opposite_player_report: right_player_report, self_reports_match:, players_have_self_reported:
+      = render 'self_report_icon', player_report: left_player_report, opposite_player_report: right_player_report, self_reports_match:, players_have_self_reported:, pairing:
       <br />
       - unless pairing.bye?
         =< render 'player_side', pairing: pairing, player: left_player, single_sided: single_sided
@@ -102,7 +102,7 @@
             | 2 for 1
     .col-sm.right_player_name
       = right_player.name_with_pronouns
-      = render 'self_report_icon', player_report: right_player_report, opposite_player_report: left_player_report, self_reports_match:, players_have_self_reported:
+      = render 'self_report_icon', player_report: right_player_report, opposite_player_report: left_player_report, self_reports_match:, players_have_self_reported:, pairing:
       <br />
       - unless pairing.bye?
         =< render 'player_side', pairing: pairing, player: right_player, single_sided: single_sided

--- a/app/views/rounds/_self_report_icon.html.slim
+++ b/app/views/rounds/_self_report_icon.html.slim
@@ -1,11 +1,11 @@
 // Both players have reported different scores -> x
 - if players_have_self_reported && !self_reports_match
-    = fa_icon 'times', class: 'differ-tooltip m-1', title: "Player reported #{player_report.score1} - #{player_report.score2}"
+    = fa_icon 'times', class: 'differ-tooltip m-1', title: "Player reported #{readable_self_report_score(pairing, player_report)}"
     javascript:
         $('.differ-tooltip').tooltip()
 // Players has reported -> check icon
 - elsif player_report != nil
-    = fa_icon 'check', class: 'report-tooltip m-1', title: "Player reported #{player_report.score1} - #{player_report.score2}"
+    = fa_icon 'check', class: 'report-tooltip m-1', title: "Player reported #{readable_self_report_score(pairing, player_report)}"
     javascript:
         $('.report-tooltip').tooltip()
 // Players hasn't reported but opponent has -> question icon, waiting


### PR DESCRIPTION
This PR adds readable scores to the TO view. Now 3-3(C) and 3-3(R) as well as the Custom Score are shown as different and in a readable format
<img width="1134" height="439" alt="Screenshot 2025-07-30 at 18 09 11" src="https://github.com/user-attachments/assets/ada5ed8e-4f82-454a-8176-3a7cedca8cb2" />
<img width="1124" height="442" alt="Screenshot 2025-07-30 at 18 09 01" src="https://github.com/user-attachments/assets/6d0a0a30-16db-43ff-8078-aa7c4e4d5ece" />

This PR duplicates the readable_score function to be usable for self reports and need to be refactored and tested in the future