### PR TITLE
feat: add pairing to self report modal

### DIFF
--- a/app/frontend/pairings/SelfReportOptions.svelte
+++ b/app/frontend/pairings/SelfReportOptions.svelte
@@ -101,7 +101,10 @@
       </div>
       <div class="modal-body">
         <p>Please click the button for the result to report this pairing:</p>
-        <p>{pairing.player1.name_with_pronouns} vs. {pairing.player2.name_with_pronouns}</p>
+        <p>
+          {pairing.player1.name_with_pronouns} vs. {pairing.player2
+            .name_with_pronouns}
+        </p>
         <div
           style="gap: 20px;"
           class="d-flex flex-row w-100 justify-content-center"


### PR DESCRIPTION
One Feedback from testing was, that it wasn't clear who is on which side in DDS self reporting.
Therefore the self reporting modal now shows the pairing:
<img width="557" height="277" alt="Screenshot 2025-07-31 at 21 13 47" src="https://github.com/user-attachments/assets/bf7bb874-6f40-4132-8b2f-c73018cf2fd8" />
