### PR TITLE
Moved bracket information from Pairing to Stage

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -114,10 +114,12 @@ class RoundsController < ApplicationController
   def pairings_data_stages
     players = pairings_data_players
     @tournament.stages.includes(:rounds).map do |stage|
-      begin
-        bracket = Bracket::Factory.bracket_for(stage.players.count) if stage.elimination?
-      rescue RuntimeError
-        bracket = nil
+      if stage.elimination?
+        begin
+          bracket = Bracket::Factory.bracket_for(stage.players.count, single_elim: stage.single_elim?)
+        rescue RuntimeError
+          bracket = nil
+        end
       end
 
       {

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -114,10 +114,18 @@ class RoundsController < ApplicationController
   def pairings_data_stages
     players = pairings_data_players
     @tournament.stages.includes(:rounds).map do |stage|
+      begin
+        bracket = Bracket::Factory.bracket_for(stage.players.count) if stage.elimination?
+      rescue RuntimeError
+        bracket = nil
+      end
+
       {
         name: stage.format.titleize,
         format: stage.format,
-        rounds: pairings_data_rounds(stage, players)
+        rounds: pairings_data_rounds(stage, players),
+        upper_bracket: bracket ? bracket.upper_bracket : [],
+        successor_games: bracket ? bracket.successor_games : {}
       }
     end
   end
@@ -154,12 +162,6 @@ class RoundsController < ApplicationController
   end
 
   def pairings_data_round(stage, players, view_decks, round)
-    begin
-      bracket = Bracket::Factory.bracket_for(stage.players.count) if stage.elimination?
-    rescue RuntimeError
-      bracket = nil
-    end
-
     pairings = []
     pairings_reported = 0
     pairings_fields = %i[id table_number player1_id player2_id side intentional_draw
@@ -208,9 +210,7 @@ class RoundsController < ApplicationController
                                  score2, score2_corp, score2_runner),
         intentional_draw:,
         two_for_one:,
-        self_report: self_report_result,
-        bracket_type: (bracket.bracket_type(table_number).to_s if bracket),
-        successor_game: (bracket.successor_game(table_number) if bracket)
+        self_report: self_report_result
       }
     end
     {

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -18,7 +18,16 @@ export async function loadPairings(
       method: "GET",
     },
   );
-  return (await response.json()) as PairingsData;
+  
+  const data = (await response.json()) as PairingsData;
+  for (const stage of data.stages)
+  {
+    stage.successor_games = new Map(Object
+      .entries(stage.successor_games)
+      .map(([k, v]) => [Number(k), Number(v)]));
+  }
+
+  return data;
 }
 export interface PairingsData {
   policy: TournamentPolicies;
@@ -34,6 +43,8 @@ export interface Stage {
   name: string;
   format: string;
   rounds: Round[];
+  upper_bracket: number[];
+  successor_games: Map<number, number>;
 }
 
 export interface Round {
@@ -54,8 +65,6 @@ export interface Pairing {
   intentional_draw: boolean;
   two_for_one: boolean;
   self_report: SelfReport | null;
-  bracket_type: string | null;
-  successor_game: number | null;
 }
 
 export interface SelfReport {

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -18,13 +18,15 @@ export async function loadPairings(
       method: "GET",
     },
   );
-  
+
   const data = (await response.json()) as PairingsData;
-  for (const stage of data.stages)
-  {
-    stage.successor_games = new Map(Object
-      .entries(stage.successor_games)
-      .map(([k, v]) => [Number(k), Number(v)]));
+  for (const stage of data.stages) {
+    stage.successor_games = new Map(
+      Object.entries(stage.successor_games).map(([k, v]) => [
+        Number(k),
+        Number(v),
+      ]),
+    );
   }
 
   return data;

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -31,6 +31,7 @@ export async function loadPairings(
 
   return data;
 }
+
 export interface PairingsData {
   policy: TournamentPolicies;
   is_player_meeting: boolean;

--- a/app/services/bracket/base.rb
+++ b/app/services/bracket/base.rb
@@ -68,12 +68,12 @@ module Bracket
       s.map { |p| Standing.new(p) }
     end
 
-    def self.bracket_type(_game_number)
-      :upper
+    def self.upper_bracket
+      []
     end
 
-    def self.successor_game(_game_number)
-      nil
+    def self.successor_games
+      {}
     end
 
     private

--- a/app/services/bracket/single_elim_top16.rb
+++ b/app/services/bracket/single_elim_top16.rb
@@ -58,6 +58,8 @@ module Bracket
       seed_of([loser(1), loser(2), loser(3), loser(4), loser(5), loser(6), loser(7), loser(8)], 8)
     ].freeze
 
+    UPPER_BRACKET = [*1..15].freeze
+
     SUCCESSOR_GAMES = {
       1 => 9,
       2 => 9,
@@ -75,8 +77,12 @@ module Bracket
       14 => 15
     }.freeze
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.upper_bracket
+      UPPER_BRACKET
+    end
+
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/single_elim_top3.rb
+++ b/app/services/bracket/single_elim_top3.rb
@@ -12,10 +12,16 @@ module Bracket
       loser(1)
     ].freeze
 
+    UPPER_BRACKET = [1, 2].freeze
+
     SUCCESSOR_GAMES = { 1 => 2 }.freeze
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.upper_bracket
+      UPPER_BRACKET
+    end
+
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/single_elim_top4.rb
+++ b/app/services/bracket/single_elim_top4.rb
@@ -14,13 +14,19 @@ module Bracket
       seed_of([loser(1), loser(2)], 2)
     ].freeze
 
+    UPPER_BRACKET = [*1..3].freeze
+
     SUCCESSOR_GAMES = {
       1 => 3,
       2 => 3
     }.freeze
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.upper_bracket
+      UPPER_BRACKET
+    end
+
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/single_elim_top8.rb
+++ b/app/services/bracket/single_elim_top8.rb
@@ -25,6 +25,8 @@ module Bracket
       seed_of([loser(1), loser(2), loser(3), loser(4)], 4)
     ].freeze
 
+    UPPER_BRACKET = [*1..7].freeze
+
     SUCCESSOR_GAMES = {
       1 => 5,
       2 => 5,
@@ -34,8 +36,12 @@ module Bracket
       6 => 7
     }.freeze
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.upper_bracket
+      UPPER_BRACKET
+    end
+
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/top16.rb
+++ b/app/services/bracket/top16.rb
@@ -61,6 +61,8 @@ module Bracket
       seed_of([loser(9), loser(10), loser(11), loser(12)], 4)
     ].freeze
 
+    UPPER_BRACKET = [1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16, 21, 22, 27, 30, 31].freeze
+
     SUCCESSOR_GAMES = {
       1 => 13,
       2 => 13,
@@ -94,14 +96,12 @@ module Bracket
       30 => 31
     }.freeze
 
-    def self.bracket_type(game_number)
-      return :lower if [9, 10, 11, 12, 17, 18, 19, 20, 23, 24, 25, 26, 28, 29].include? game_number
-
-      :upper
+    def self.upper_bracket
+      UPPER_BRACKET
     end
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/top4.rb
+++ b/app/services/bracket/top4.rb
@@ -21,6 +21,8 @@ module Bracket
       loser(4)
     ].freeze
 
+    UPPER_BRACKET = [1, 2, 3, 6, 7].freeze
+
     SUCCESSOR_GAMES = {
       1 => 3,
       2 => 3,
@@ -30,14 +32,12 @@ module Bracket
       6 => 7
     }.freeze
 
-    def self.bracket_type(game_number)
-      return :lower if [4, 5].include? game_number
-
-      :upper
+    def self.upper_bracket
+      UPPER_BRACKET
     end
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -35,7 +35,7 @@ module Bracket
       seed_of([loser(7), loser(8)], 2)
     ].freeze
 
-    UPPER_BRACKET = [1, 2, 3, 4, 5, 6, 9, 14].freeze
+    UPPER_BRACKET = [1, 2, 3, 4, 5, 6, 9, 14, 15].freeze
 
     SUCCESSOR_GAMES = {
       1 => 5,

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -35,6 +35,8 @@ module Bracket
       seed_of([loser(7), loser(8)], 2)
     ].freeze
 
+    UPPER_BRACKET = [1, 2, 3, 4, 5, 6, 9, 14].freeze
+
     SUCCESSOR_GAMES = {
       1 => 5,
       2 => 5,
@@ -52,14 +54,12 @@ module Bracket
       14 => 15
     }.freeze
 
-    def self.bracket_type(game_number)
-      return :lower if [7, 8, 10, 11, 12, 13].include? game_number
-
-      :upper
+    def self.upper_bracket
+      UPPER_BRACKET
     end
 
-    def self.successor_game(game_number)
-      SUCCESSOR_GAMES[game_number]
+    def self.successor_games
+      SUCCESSOR_GAMES
     end
   end
 end

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe RoundsController do
           .to eq(
             'is_player_meeting' => true,
             'policy' => { 'update' => false },
-            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+            'stages' => [{
+              'name' => 'Swiss',
+              'format' => 'swiss',
+              'rounds' => [],
+              'upper_bracket' => [],
+              'successor_games' => {}
+            }]
           )
       end
 
@@ -29,7 +35,13 @@ RSpec.describe RoundsController do
           .to eq(
             'is_player_meeting' => true,
             'policy' => { 'update' => false },
-            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+            'stages' => [{
+              'name' => 'Swiss',
+              'format' => 'swiss',
+              'rounds' => [],
+              'upper_bracket' => [],
+              'successor_games' => {}
+            }]
           )
       end
 
@@ -41,7 +53,13 @@ RSpec.describe RoundsController do
           .to eq(
             'is_player_meeting' => true,
             'policy' => { 'update' => true },
-            'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [] }]
+            'stages' => [{
+              'name' => 'Swiss',
+              'format' => 'swiss',
+              'rounds' => [],
+              'upper_bracket' => [],
+              'successor_games' => {}
+            }]
           )
       end
     end
@@ -58,29 +76,31 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
-                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
-                     {
-                       'number' => 1,
-                       'pairings' => [
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Charlie (she/her)'),
-                           'player2' => player_with_no_ids('Bob (he/him)'),
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => ' - ', 'two_for_one' => false,
-                           'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil },
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Alice (she/her)'),
-                           'player2' => bye_player,
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => '6 - 0', 'two_for_one' => false,
-                           'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil }
-                       ], 'pairings_reported' => 1
-                     }
-                   ] }]
+                   'stages' => [{
+                     'name' => 'Swiss',
+                     'format' => 'swiss',
+                     'rounds' => [
+                       {
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Charlie (she/her)'),
+                             'player2' => player_with_no_ids('Bob (he/him)'),
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => ' - ', 'two_for_one' => false,
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Alice (she/her)'),
+                             'player2' => bye_player,
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => '6 - 0', 'two_for_one' => false,
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                         ], 'pairings_reported' => 1
+                       }
+                     ],
+                     'upper_bracket' => [],
+                     'successor_games' => {}
+                   }]
                  })
       end
 
@@ -91,29 +111,37 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => true },
-                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
-                     {
-                       'number' => 1,
-                       'pairings' => [
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Charlie (she/her)'),
-                           'player2' => player_with_no_ids('Bob (he/him)'),
-                           'policy' => { 'view_decks' => false, 'self_report' => false }, # sees player view as a player
-                           'score_label' => ' - ', 'two_for_one' => false,
-                           'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil },
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Alice (she/her)'),
-                           'player2' => bye_player,
-                           'policy' => { 'view_decks' => false, 'self_report' => false }, # sees player view as a player
-                           'score_label' => '6 - 0', 'two_for_one' => false,
-                           'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil }
-                       ], 'pairings_reported' => 1
-                     }
-                   ] }]
+                   'stages' => [{
+                     'name' => 'Swiss',
+                     'format' => 'swiss',
+                     'rounds' => [
+                       {
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Charlie (she/her)'),
+                             'player2' => player_with_no_ids('Bob (he/him)'),
+                             'policy' => {
+                               'view_decks' => false,
+                               'self_report' => false
+                             }, # sees player view as a player
+                             'score_label' => ' - ', 'two_for_one' => false,
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Alice (she/her)'),
+                             'player2' => bye_player,
+                             'policy' => {
+                               'view_decks' => false,
+                               'self_report' => false
+                             }, # sees player view as a player
+                             'score_label' => '6 - 0', 'two_for_one' => false,
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                         ], 'pairings_reported' => 1
+                       }
+                     ],
+                     'upper_bracket' => [],
+                     'successor_games' => {}
+                   }]
                  })
       end
     end
@@ -133,44 +161,50 @@ RSpec.describe RoundsController do
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
                    'stages' => [
-                     { 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
-                       {
-                         'number' => 1,
-                         'pairings' => [
-                           { 'intentional_draw' => false,
-                             'player1' => player_with_no_ids('Charlie (she/her)'),
-                             'player2' => player_with_no_ids('Bob (he/him)'),
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
-                             'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'bracket_type' => nil,
-                             'successor_game' => nil },
-                           { 'intentional_draw' => false,
-                             'player1' => player_with_no_ids('Alice (she/her)'),
-                             'player2' => bye_player,
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
-                             'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'bracket_type' => nil,
-                             'successor_game' => nil }
-                         ], 'pairings_reported' => 1
-                       }
-                     ] },
-                     { 'name' => 'Double Elim', 'format' => 'double_elim', 'rounds' => [
-                       {
-                         'number' => 1,
-                         'pairings' => [
-                           { 'intentional_draw' => false,
-                             'player1' => player_with_no_ids('Bob (he/him)'),
-                             'player2' => player_with_no_ids('Charlie (she/her)'),
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
-                             'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil,
-                             'bracket_type' => 'upper',
-                             'successor_game' => 2 }
-                         ], 'pairings_reported' => 0
-                       }
-                     ] }
+                     {
+                       'name' => 'Swiss',
+                       'format' => 'swiss',
+                       'rounds' => [
+                         {
+                           'number' => 1,
+                           'pairings' => [
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Charlie (she/her)'),
+                               'player2' => player_with_no_ids('Bob (he/him)'),
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'score_label' => ' - ', 'two_for_one' => false,
+                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Alice (she/her)'),
+                               'player2' => bye_player,
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'score_label' => '6 - 0', 'two_for_one' => false,
+                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                           ], 'pairings_reported' => 1
+                         }
+                       ],
+                       'upper_bracket' => [],
+                       'successor_games' => {}
+                     },
+                     {
+                       'name' => 'Double Elim',
+                       'format' => 'double_elim',
+                       'rounds' => [
+                         {
+                           'number' => 1,
+                           'pairings' => [
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Bob (he/him)'),
+                               'player2' => player_with_no_ids('Charlie (she/her)'),
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'score_label' => ' - ', 'two_for_one' => false,
+                               'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil }
+                           ], 'pairings_reported' => 0
+                         }
+                       ],
+                       'upper_bracket' => [1, 2],
+                       'successor_games' => { '1' => 2 }
+                     }
                    ]
                  })
       end
@@ -193,29 +227,31 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
-                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
-                     {
-                       'number' => 1,
-                       'pairings' => [
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Charlie (she/her)', side: 'corp', side_label: '(Corp)'),
-                           'player2' => player_with_no_ids('Bob (he/him)', side: 'runner', side_label: '(Runner)'),
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => '3 - 0 (C)', 'two_for_one' => false,
-                           'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil },
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Alice (she/her)'),
-                           'player2' => bye_player,
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => '6 - 0', 'two_for_one' => false,
-                           'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil }
-                       ], 'pairings_reported' => 2
-                     }
-                   ] }]
+                   'stages' => [{
+                     'name' => 'Swiss',
+                     'format' => 'swiss',
+                     'rounds' => [
+                       {
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Charlie (she/her)', side: 'corp', side_label: '(Corp)'),
+                             'player2' => player_with_no_ids('Bob (he/him)', side: 'runner', side_label: '(Runner)'),
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => '3 - 0 (C)', 'two_for_one' => false,
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Alice (she/her)'),
+                             'player2' => bye_player,
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => '6 - 0', 'two_for_one' => false,
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                         ], 'pairings_reported' => 2
+                       }
+                     ],
+                     'upper_bracket' => [],
+                     'successor_games' => {}
+                   }]
                  })
       end
     end
@@ -237,29 +273,33 @@ RSpec.describe RoundsController do
           .to eq({
                    'is_player_meeting' => false,
                    'policy' => { 'update' => false },
-                   'stages' => [{ 'name' => 'Swiss', 'format' => 'swiss', 'rounds' => [
-                     {
-                       'number' => 1,
-                       'pairings' => [
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Charlie (she/her)', side: 'runner', side_label: '(Runner)'),
-                           'player2' => player_with_no_ids('Bob (he/him)', side: 'corp', side_label: '(Corp)'),
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => '0 - 3 (R)', 'two_for_one' => false,
-                           'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil },
-                         { 'intentional_draw' => false,
-                           'player1' => player_with_no_ids('Alice (she/her)'),
-                           'player2' => bye_player,
-                           'policy' => { 'view_decks' => false, 'self_report' => false },
-                           'score_label' => '6 - 0', 'two_for_one' => false,
-                           'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                           'bracket_type' => nil,
-                           'successor_game' => nil }
-                       ], 'pairings_reported' => 2
-                     }
-                   ] }]
+                   'stages' => [{
+                     'name' => 'Swiss',
+                     'format' => 'swiss',
+                     'rounds' => [
+                       {
+                         'number' => 1,
+                         'pairings' => [
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids(
+                               'Charlie (she/her)', side: 'runner', side_label: '(Runner)'
+                             ),
+                             'player2' => player_with_no_ids('Bob (he/him)', side: 'corp', side_label: '(Corp)'),
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => '0 - 3 (R)', 'two_for_one' => false,
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                           { 'intentional_draw' => false,
+                             'player1' => player_with_no_ids('Alice (she/her)'),
+                             'player2' => bye_player,
+                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'score_label' => '6 - 0', 'two_for_one' => false,
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                         ], 'pairings_reported' => 2
+                       }
+                     ],
+                     'upper_bracket' => [],
+                     'successor_games' => {}
+                   }]
                  })
       end
     end


### PR DESCRIPTION
The bracket information is now on the `Stage` JS object instead of the `Pairing` object so that all bracket information is available on the front end before all pairings are made.

`Stage::upper_bracket` is an array containing the table numbers that comprise the upper bracket.
`Stage::successor_games` is a map that maps every table number to the table that the winner progresses to.