### PR TITLE
TO self report accept button

### DIFF
--- a/app/views/rounds/_pairings.html.slim
+++ b/app/views/rounds/_pairings.html.slim
@@ -141,13 +141,9 @@
                    = fa_icon 'hourglass', class: 'missing-report-tooltip m-1'
               .modal-footer
                 - if left_player_report
-                  .btn.btn-primary.disabled
-                    => fa_icon 'check'
-                    | Accept #{left_player.name}
+                  => render 'self_report_form', pairing:, round:, player: left_player, report: left_player_report
                 - if right_player_report
-                  .btn.btn-primary.disabled
-                    => fa_icon 'check'
-                    | Accept #{right_player.name}
+                  => render 'self_report_form', pairing:, round:, player: right_player, report: right_player_report
                 - if players_have_self_reported && !self_reports_match
                   = link_to reset_self_report_tournament_round_pairing_path(round.tournament, round, pairing),
                     method: :delete, title: 'Reset self reports of pairing', class: 'btn btn-primary reset-self-reports',

--- a/app/views/rounds/_self_report_form.html.slim
+++ b/app/views/rounds/_self_report_form.html.slim
@@ -1,0 +1,11 @@
+ = simple_form_for pairing, url: report_tournament_round_pairing_path(round.tournament, round, pairing), method: :post, html: { class: 'form-inline' } do |f|
+    .mx-auto
+        = f.hidden_field :score1_runner, value: 0
+        = f.hidden_field :score1_corp, value: 0
+        = f.hidden_field :score2_runner, value: 0
+        = f.hidden_field :score2_corp, value: 0
+        = f.hidden_field :score1, value: report.score1
+        = f.hidden_field :score2, value: report.score2
+        = button_tag type: :submit, class: "btn btn-primary mx-2", disabled: pairing.reported? do                
+            => fa_icon 'check'
+            | Accept #{player.name}


### PR DESCRIPTION
This PR adds the possibility for the TO to accept a single self report.
With that two stage self reporting with auto acceptance and single side / mixed self reporting are now usable for TOs

ps: I hope player1_not_corp isn't an issue here because score/player assignment for self reporting is already done and my manual tests seemed to work