### PR TITLE
Tournament organizer fixes

### DIFF
--- a/app/assets/javascripts/nrdb_cards.js.coffee.erb
+++ b/app/assets/javascripts/nrdb_cards.js.coffee.erb
@@ -18,7 +18,6 @@ $(document).on 'turbolinks:load', ->
       getPrintings({
         data: {
           'filter[search]': query,
-          'filter[distinct_cards]': '',
           'page[size]': 10000
         },
         success: (response) =>

--- a/app/assets/javascripts/nrdb_cards.js.coffee.erb
+++ b/app/assets/javascripts/nrdb_cards.js.coffee.erb
@@ -18,6 +18,7 @@ $(document).on 'turbolinks:load', ->
       getPrintings({
         data: {
           'filter[search]': query,
+          'filter[distinct_cards]': '',
           'page[size]': 10000
         },
         success: (response) =>

--- a/app/assets/javascripts/nrdb_cards.js.coffee.erb
+++ b/app/assets/javascripts/nrdb_cards.js.coffee.erb
@@ -18,7 +18,7 @@ $(document).on 'turbolinks:load', ->
       getPrintings({
         data: {
           'filter[search]': query,
-          'filter[distinct_cards]': '',
+          'filter[distinct_cards]': true,
           'page[size]': 10000
         },
         success: (response) =>

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -298,7 +298,8 @@ class PlayersController < ApplicationController
   def player_params
     params.require(:player)
           .permit(:name, :pronouns, :corp_identity, :runner_identity, :corp_deck, :runner_deck,
-                  :first_round_bye, :manual_seed, :include_in_stream, :fixed_table_number)
+                  :first_round_bye, :manual_seed, :include_in_stream, :fixed_table_number,
+                  :organiser_view, :registration_view)
   end
 
   def organiser_view?

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -96,7 +96,6 @@ class PlayersController < ApplicationController
       return
     end
     details = request['details']
-    return if details['user_id'] && details['user_id'] != current_user.id
 
     details.keep_if { |key| Deck.column_names.include? key }
     details['side_id'] = side

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -87,7 +87,7 @@ class PlayersController < ApplicationController
   end
 
   def save_deck(params, param, side)
-    return unless params.key?(param)
+    return if !params.key?(param) || (params['user_id'] && params['user_id'] != current_user.id)
 
     begin
       request = JSON.parse(params[param])

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -18,6 +18,8 @@ class Player < ApplicationRecord
   scope :dropped, -> { where(active: false) }
   scope :with_first_round_bye, -> { where(first_round_bye: true) }
 
+  attr_accessor :organiser_view, :registration_view
+
   def pairings
     Pairing.for_player(self)
   end

--- a/app/views/players/_form.html.slim
+++ b/app/views/players/_form.html.slim
@@ -25,18 +25,16 @@
     = f.input_field :pronouns,
             placeholder: 'Example: they/them',
             class: 'form-control'
-  - if !@tournament.nrdb_deck_registration? or not defined?(new_registration)
+  - if not defined?(new_registration)
     .form-group
       label.d-block for="player_corp_identity" Corp ID
       = f.input_field :corp_identity,
-              readonly: @tournament.nrdb_deck_registration?,
-              placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for corp ID'),
+              placeholder: 'Search for corp ID',
               class: 'form-control corp_identities'
     .form-group
       label.d-block for="player_runner_identity" Runner ID
       = f.input_field :runner_identity,
-              readonly: @tournament.nrdb_deck_registration?,
-              placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for runner ID'),
+              placeholder: 'Search for runner ID',
               class: 'form-control runner_identities'
   - if defined?(new_registration) and not defined?(organiser_view)
     .form-group

--- a/app/views/players/_form.html.slim
+++ b/app/views/players/_form.html.slim
@@ -25,16 +25,18 @@
     = f.input_field :pronouns,
             placeholder: 'Example: they/them',
             class: 'form-control'
-  - if not defined?(new_registration)
+  - if !@tournament.nrdb_deck_registration? or not defined?(new_registration)
     .form-group
       label.d-block for="player_corp_identity" Corp ID
       = f.input_field :corp_identity,
-              placeholder: 'Search for corp ID',
+              readonly: @tournament.nrdb_deck_registration?,
+              placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for corp ID'),
               class: 'form-control corp_identities'
     .form-group
       label.d-block for="player_runner_identity" Runner ID
       = f.input_field :runner_identity,
-              placeholder: 'Search for runner ID',
+              readonly: @tournament.nrdb_deck_registration?,
+              placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for runner ID'),
               class: 'form-control runner_identities'
   - if defined?(new_registration) and not defined?(organiser_view)
     .form-group

--- a/app/views/players/_form.html.slim
+++ b/app/views/players/_form.html.slim
@@ -29,11 +29,13 @@
     .form-group
       label.d-block for="player_corp_identity" Corp ID
       = f.input_field :corp_identity,
+              readonly: @tournament.nrdb_deck_registration?,
               placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for corp ID'),
               class: 'form-control corp_identities'
     .form-group
       label.d-block for="player_runner_identity" Runner ID
       = f.input_field :runner_identity,
+              readonly: @tournament.nrdb_deck_registration?,
               placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for runner ID'),
               class: 'form-control runner_identities'
   - if defined?(new_registration) and not defined?(organiser_view)

--- a/app/views/players/_form.html.slim
+++ b/app/views/players/_form.html.slim
@@ -29,13 +29,11 @@
     .form-group
       label.d-block for="player_corp_identity" Corp ID
       = f.input_field :corp_identity,
-              readonly: @tournament.nrdb_deck_registration?,
               placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for corp ID'),
               class: 'form-control corp_identities'
     .form-group
       label.d-block for="player_runner_identity" Runner ID
       = f.input_field :runner_identity,
-              readonly: @tournament.nrdb_deck_registration?,
               placeholder: (@tournament.nrdb_deck_registration? ? '' : 'Search for runner ID'),
               class: 'form-control runner_identities'
   - if defined?(new_registration) and not defined?(organiser_view)


### PR DESCRIPTION
These changes address issues preventing TOs from modifying players' decklists and selected IDs. These fixes are tentative and definitely need more experienced sets of eyes on them.