### PR TITLE
Update decklists view to print in 2 columns

### DIFF
--- a/app/assets/stylesheets/players.sass
+++ b/app/assets/stylesheets/players.sass
@@ -25,9 +25,9 @@
 
 @media print 
   #display_player_decks 
-    display: block;
-    column-count: 2;
-    -webkitcolumn-count: 2;
-    -moz-column-count: 2;
+    display: block
+    column-count: 2
+    -webkitcolumn-count: 2
+    -moz-column-count: 2
   
 

--- a/app/assets/stylesheets/players.sass
+++ b/app/assets/stylesheets/players.sass
@@ -24,6 +24,10 @@
         margin-right: 0.5rem
 
 @media print 
+  .container 
+    max-width: 100%
+    width: 100%
+    
   #display_player_decks 
     display: block
     column-count: 2

--- a/app/assets/stylesheets/players.sass
+++ b/app/assets/stylesheets/players.sass
@@ -22,3 +22,12 @@
 
       &:not(:last-child)
         margin-right: 0.5rem
+
+@media print 
+  #display_player_decks 
+    display: block;
+    column-count: 2;
+    -webkitcolumn-count: 2;
+    -moz-column-count: 2;
+  
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,11 +3,20 @@
 require 'redcarpet'
 
 module ApplicationHelper
+<<<<<<< HEAD
   class ResponsiveImgRenderer < Redcarpet::Render::HTML
     def image(link, _title, alt_text)
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
     end
   end
+=======
+
+  class ResponsiveImgRenderer < Redcarpet::Render::HTML 
+    def image(link, title, alt_text) 
+      %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
+    end 
+  end 
+>>>>>>> b9adddd (use img-fluid class on images)
 
   def markdown(text)
     options = {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,20 +3,11 @@
 require 'redcarpet'
 
 module ApplicationHelper
-<<<<<<< HEAD
   class ResponsiveImgRenderer < Redcarpet::Render::HTML
     def image(link, _title, alt_text)
       %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
     end
   end
-=======
-
-  class ResponsiveImgRenderer < Redcarpet::Render::HTML 
-    def image(link, title, alt_text) 
-      %(<img class="img-fluid" src=#{link} alt=#{alt_text}>)
-    end 
-  end 
->>>>>>> b9adddd (use img-fluid class on images)
 
   def markdown(text)
     options = {


### PR DESCRIPTION
Added some styling to print in two columns and then for some reason the display: flex setup breaks it so only render with display:block for print medium (this shouldn't disrupt the browser view unless you manually toggle and enable viewing as if print media) 
<img width="1748" height="1510" alt="image" src="https://github.com/user-attachments/assets/ac9ee4ee-8a52-47e9-aed6-7eafa4ae837f" />
