### PR TITLE
Simplify standings data

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
     resources :players, only: %i[index new create update destroy] do
       get :standings, on: :collection
       get :standings_data, on: :collection
-      get :new_standings_data, on: :collection
       get :meeting, on: :collection
       get :download_decks, on: :collection
       get :download_streaming, on: :collection

--- a/spec/requests/players_controller_spec.rb
+++ b/spec/requests/players_controller_spec.rb
@@ -561,8 +561,9 @@ RSpec.describe PlayersController do
       'points' => 0,
       'sos' => 0,
       'extended_sos' => 0,
-      'runner_points' => 0,
+      'bye_points' => 0,
       'corp_points' => 0,
+      'runner_points' => 0,
       'manual_seed' => nil,
       'side_bias' => nil
     }
@@ -596,8 +597,8 @@ RSpec.describe PlayersController do
   def player_with_hidden_ids(name_with_pronouns)
     {
       'name_with_pronouns' => name_with_pronouns,
-      'corp_id' => nil,
-      'runner_id' => nil,
+      'corp_id' => { 'faction' => nil, 'name' => nil },
+      'runner_id' => { 'faction' => nil, 'name' => nil },
       'active' => true
     }
   end


### PR DESCRIPTION
This unifies a couple of things that were different for no great reason in the standings data, specifically the corp id structure (null in one case, an object with a null name and faction in another).

This change turns the performance for the standings_data json endpoint down to roughly constant, instead of ever-growing.

Comparison locally for a 120 person 10 round SSS tournament before:
```
Completed 200 OK in 709ms (Views: 1.6ms | ActiveRecord: 34.3ms (610 queries, 260 cached) | GC: 290.6ms)
Completed 200 OK in 868ms (Views: 16.1ms | ActiveRecord: 49.9ms (850 queries, 416 cached) | GC: 225.9ms)
Completed 200 OK in 905ms (Views: 2.0ms | ActiveRecord: 59.3ms (1090 queries, 649 cached) | GC: 155.5ms)
Completed 200 OK in 884ms (Views: 2.3ms | ActiveRecord: 46.8ms (1330 queries, 877 cached) | GC: 108.9ms)
Completed 200 OK in 1184ms (Views: 3.3ms | ActiveRecord: 72.9ms (1570 queries, 1124 cached) | GC: 161.3ms)
Completed 200 OK in 1156ms (Views: 2.8ms | ActiveRecord: 57.0ms (1810 queries, 1340 cached) | GC: 155.4ms)
Completed 200 OK in 1515ms (Views: 2.5ms | ActiveRecord: 65.3ms (2050 queries, 1550 cached) | GC: 356.9ms)
Completed 200 OK in 1402ms (Views: 2.6ms | ActiveRecord: 64.3ms (2290 queries, 1795 cached) | GC: 150.0ms)
Completed 200 OK in 1797ms (Views: 1.7ms | ActiveRecord: 74.4ms (2530 queries, 2012 cached) | GC: 417.0ms)
Completed 200 OK in 1973ms (Views: 3.7ms | ActiveRecord: 103.5ms (2770 queries, 2244 cached) | GC: 215.5ms)
```

and after:
```
Completed 200 OK in 99ms (Views: 7.1ms | ActiveRecord: 23.9ms (4 queries, 1 cached) | GC: 6.5ms)
Completed 200 OK in 90ms (Views: 10.0ms | ActiveRecord: 12.7ms (4 queries, 1 cached) | GC: 32.9ms)
Completed 200 OK in 83ms (Views: 6.6ms | ActiveRecord: 36.9ms (4 queries, 1 cached) | GC: 1.5ms)
Completed 200 OK in 87ms (Views: 22.6ms | ActiveRecord: 22.8ms (4 queries, 1 cached) | GC: 4.5ms)
Completed 200 OK in 77ms (Views: 13.5ms | ActiveRecord: 24.9ms (4 queries, 1 cached) | GC: 15.0ms)
Completed 200 OK in 68ms (Views: 7.7ms | ActiveRecord: 36.9ms (4 queries, 1 cached) | GC: 16.0ms)
Completed 200 OK in 57ms (Views: 11.2ms | ActiveRecord: 17.1ms (4 queries, 1 cached) | GC: 0.0ms)
Completed 200 OK in 43ms (Views: 7.0ms | ActiveRecord: 12.5ms (4 queries, 1 cached) | GC: 0.0ms)
Completed 200 OK in 60ms (Views: 6.4ms | ActiveRecord: 19.8ms (4 queries, 1 cached) | GC: 0.0ms)
Completed 200 OK in 65ms (Views: 11.1ms | ActiveRecord: 21.5ms (4 queries, 1 cached) | GC: 7.7ms)
```