### PR TITLE
Hide self report button when self reporting is disabled

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -7,7 +7,7 @@ class RoundsController < ApplicationController
   def index
     authorize @tournament, :update?
     @stages = @tournament.stages.includes(
-      :tournament, rounds: [:tournament, :stage, { pairings: %i[tournament stage round self_reports] }]
+      :tournament, rounds: [:tournament, :stage, { pairings: %i[tournament stage round self_reports player1 player2] }]
     )
     @players = @tournament.players
                           .includes(:corp_identity_ref, :runner_identity_ref)

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -212,7 +212,7 @@ class RoundsController < ApplicationController
                                                          self_report,
                                                          players[player1_id]&.dig('user_id'),
                                                          players[player2_id]&.dig('user_id')) &&
-                       score1.nil? && score2.nil?
+                       score1.nil? && score2.nil? && @tournament.allow_self_reporting
         },
         # TODO: in future pass current user to svelte frontend
         ui_metadata: {

--- a/app/frontend/pairings/SelfReport.ts
+++ b/app/frontend/pairings/SelfReport.ts
@@ -62,7 +62,7 @@ export interface SelfReportPresets {
   score2_runner: number;
   intentional_draw: boolean;
   label: string;
-  extra_self_report_label: string;
+  extra_self_report_label?: string;
 }
 
 export interface SelfReport {

--- a/app/frontend/pairings/SelfReport.ts
+++ b/app/frontend/pairings/SelfReport.ts
@@ -62,7 +62,7 @@ export interface SelfReportPresets {
   score2_runner: number;
   intentional_draw: boolean;
   label: string;
-  extra_self_report_label: string
+  extra_self_report_label: string;
 }
 
 export interface SelfReport {

--- a/app/frontend/pairings/SelfReport.ts
+++ b/app/frontend/pairings/SelfReport.ts
@@ -62,6 +62,7 @@ export interface SelfReportPresets {
   score2_runner: number;
   intentional_draw: boolean;
   label: string;
+  extra_self_report_label: string
 }
 
 export interface SelfReport {

--- a/app/frontend/pairings/SelfReportOptions.svelte
+++ b/app/frontend/pairings/SelfReportOptions.svelte
@@ -142,7 +142,7 @@
                   return onSelfReportPresetClicked(preset);
                 }}
               >
-                {preset.label}
+                {preset.extra_self_report_label ?? preset.label}
               </button>
             {/each}
           {:else}

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -97,14 +97,14 @@ module PairingsHelper
     if pairing.stage.elimination? && !pairing.side.nil?
       if pairing.player1_is_corp?
         return [
-          { score1: 3, score2: 0, score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: '3-0' },
-          { score1: 0, score2: 3, score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: '0-3' }
+          { score1: 3, score2: 0, score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: "#{pairing.player1.name} wins" },
+          { score1: 0, score2: 3, score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: "#{pairing.player2.name} wins" }
         ]
       else
         # Player 1 is runner
         return [
-          { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 3, score2_runner: 0, label: '3-0' },
-          { score1: 3, score1_corp: 0, score1_runner: 3, score2: 0, score2_corp: 0, score2_runner: 0, label: '0-3' }
+          { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 3, score2_runner: 0, label: "#{pairing.player2.name} wins" },
+          { score1: 3, score1_corp: 0, score1_runner: 3, score2: 0, score2_corp: 0, score2_runner: 0, label: "#{pairing.player1.name} wins" }
         ]
       end
     end

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -97,14 +97,18 @@ module PairingsHelper
     if pairing.stage.elimination? && !pairing.side.nil?
       if pairing.player1_is_corp?
         return [
-          { score1: 3, score2: 0, score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0, label: "#{pairing.player1.name} wins" },
-          { score1: 0, score2: 3, score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0, label: "#{pairing.player2.name} wins" }
+          { score1: 3, score2: 0, score1_corp: 3, score2_runner: 0, score1_runner: 0, score2_corp: 0,
+            label: '3-0', extra_self_report_label: "#{pairing.player1.name} wins" },
+          { score1: 0, score2: 3, score1_corp: 0, score2_runner: 3, score1_runner: 0, score2_corp: 0,
+            label: '0-3', extra_self_report_label: "#{pairing.player2.name} wins" }
         ]
       else
         # Player 1 is runner
         return [
-          { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 3, score2_runner: 0, label: "#{pairing.player2.name} wins" },
-          { score1: 3, score1_corp: 0, score1_runner: 3, score2: 0, score2_corp: 0, score2_runner: 0, label: "#{pairing.player1.name} wins" }
+          { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 3, score2_runner: 0,
+            label: '3-0', extra_self_report_label: "#{pairing.player2.name} wins" },
+          { score1: 3, score1_corp: 0, score1_runner: 3, score2: 0, score2_corp: 0, score2_runner: 0,
+            label: '0-3', extra_self_report_label: "#{pairing.player1.name} wins" }
         ]
       end
     end

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe PairingsHelper do
           expect(helper.presets(pairing)).to eq(
             [
               { score1: 3, score1_corp: 3, score1_runner: 0, score2: 0, score2_corp: 0, score2_runner: 0,
-                label: '3-0' },
-              { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 0, score2_runner: 3, label: '0-3' }
+                label: '3-0', extra_self_report_label: "#{pairing.player1.name} wins" },
+              { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 0, score2_runner: 3, label: '0-3', extra_self_report_label: "#{pairing.player2.name} wins" }
             ]
           )
         end
@@ -108,9 +108,9 @@ RSpec.describe PairingsHelper do
           expect(helper.presets(pairing)).to eq(
             [
               { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 3, score2_runner: 0,
-                label: '3-0' },
+                label: '3-0', extra_self_report_label: "#{pairing.player2.name} wins" },
               { score1: 3, score1_corp: 0, score1_runner: 3, score2: 0, score2_corp: 0, score2_runner: 0,
-                label: '0-3' }
+                label: '0-3', extra_self_report_label: "#{pairing.player1.name} wins" }
             ]
           )
         end

--- a/spec/helpers/pairings_helper_spec.rb
+++ b/spec/helpers/pairings_helper_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe PairingsHelper do
             [
               { score1: 3, score1_corp: 3, score1_runner: 0, score2: 0, score2_corp: 0, score2_runner: 0,
                 label: '3-0', extra_self_report_label: "#{pairing.player1.name} wins" },
-              { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 0, score2_runner: 3, label: '0-3', extra_self_report_label: "#{pairing.player2.name} wins" }
+              { score1: 0, score1_corp: 0, score1_runner: 0, score2: 3, score2_corp: 0, score2_runner: 3, label: '0-3',
+                extra_self_report_label: "#{pairing.player2.name} wins" }
             ]
           )
         end


### PR DESCRIPTION
Self Report button showed up even when tournament has it disabled. It was caught in backend but not shown in the ui.
Adding tournament.allow_self_reporting to the pairing policies fixes it.