### PR TITLE
fix: show self report button only when tournament settings allows it

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -212,7 +212,7 @@ class RoundsController < ApplicationController
                                                          self_report,
                                                          players[player1_id]&.dig('user_id'),
                                                          players[player2_id]&.dig('user_id')) &&
-                       score1.nil? && score2.nil?
+                       score1.nil? && score2.nil? && @tournament.allow_self_reporting
         },
         # TODO: in future pass current user to svelte frontend
         ui_metadata: {


### PR DESCRIPTION
Self Report button showed up even when tournament has it disabled. It was caught in backend but not shown in the ui.
Adding tournament.allow_self_reporting to the pairing policies fixes it.