### PR TITLE
Re-remove player_match_reports table not added in any migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,27 +170,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_054120) do
     t.index ["round_id"], name: "index_pairings_on_round_id"
   end
 
-  create_table "player_match_reports", id: false, force: :cascade do |t|
-    t.integer "tournament_id", null: false
-    t.integer "round_id", null: false
-    t.integer "pairing_id", null: false
-    t.integer "player_id", null: false
-    t.integer "player1_id", null: false
-    t.integer "player2_id", null: false
-    t.integer "score1"
-    t.integer "score2"
-    t.integer "side"
-    t.integer "score1_runner"
-    t.integer "score1_corp"
-    t.integer "score2_corp"
-    t.integer "score2_runner"
-    t.boolean "intentional_draw", default: false, null: false
-    t.boolean "two_for_one", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["tournament_id", "round_id", "pairing_id", "player_id"], name: "idx_unq_id_player_match_reports", unique: true
-  end
-
   create_table "players", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "tournament_id"


### PR DESCRIPTION
@plural it looks like you added this back in in PR https://github.com/Project-NISEI/cobra/pull/595. It looks as though you have a database table locally that doesn't exist in the repo?

Every time I apply the database migrations locally it automatically updates the schema to re-remove this, because it's not in any migration. What is it?