### PR TITLE
Fixing table range key

### DIFF
--- a/app/frontend/stages/StageSettings.svelte
+++ b/app/frontend/stages/StageSettings.svelte
@@ -117,7 +117,7 @@
           {#if error}
             <div class="alert alert-danger">{error}</div>
           {/if}
-          {#each data.stage.table_ranges as tableRange (tableRange.id)}
+          {#each data.stage.table_ranges as tableRange (tableRange.first_table)}
             <TableRangeEdit stage={data.stage} {tableRange} />
           {/each}
           <TableRangeEdit bind:this={newTableRangeEdit} stage={data.stage} />


### PR DESCRIPTION
This is a fix for a bug I found while poking around - using the table range ID for the key would cause multiple new (and thus ID-less) rows to clobber each other, so it needs to be set to something unique. Table ranges can't overlap so no two ranges can have the same first table.