### PR TITLE
Key bracket nodes on table number, not ID

### DIFF
--- a/app/frontend/bracket/BracketDisplay.svelte
+++ b/app/frontend/bracket/BracketDisplay.svelte
@@ -248,42 +248,42 @@
     {#if upperRounds.length > 0}
       <g>
         <g>
-        <!-- Connectors -->
-        {#each upperCols as col, cIdx (cIdx)}
-          {#each col as m, rIdx (m.table_number)}
-            {#if m.winner_game != null}
-              {#if upperIndex.has(String(m.winner_game))}
-                <path
-                  d={connectorPathTo(
-                    upperIndex,
-                    cIdx,
-                    rIdx,
-                    m.winner_game,
-                    upperY,
-                  )}
-                  stroke="#999"
-                  fill="none"
-                />
+          <!-- Connectors -->
+          {#each upperCols as col, cIdx (cIdx)}
+            {#each col as m, rIdx (m.table_number)}
+              {#if m.winner_game != null}
+                {#if upperIndex.has(String(m.winner_game))}
+                  <path
+                    d={connectorPathTo(
+                      upperIndex,
+                      cIdx,
+                      rIdx,
+                      m.winner_game,
+                      upperY,
+                    )}
+                    stroke="#999"
+                    fill="none"
+                  />
+                {/if}
               {/if}
-            {/if}
+            {/each}
+          {/each}
+        </g>
+
+        <!-- Matches -->
+        {#each upperCols as col, cIdx (cIdx)}
+          {#each col as match, rIdx (match.table_number)}
+            <BracketMatchNode
+              {match}
+              allMatches={allPairings}
+              {predecessorMap}
+              x={columnX(cIdx)}
+              y={upperY[cIdx]?.[rIdx] ?? baseMatchY(rIdx)}
+              width={columnWidth}
+              height={matchHeight}
+            />
           {/each}
         {/each}
-      </g>
-
-      <!-- Matches -->
-      {#each upperCols as col, cIdx (cIdx)}
-        {#each col as match, rIdx (match.table_number)}
-          <BracketMatchNode
-            {match}
-            allMatches={allPairings}
-            {predecessorMap}
-            x={columnX(cIdx)}
-            y={upperY[cIdx]?.[rIdx] ?? baseMatchY(rIdx)}
-            width={columnWidth}
-            height={matchHeight}
-          />
-        {/each}
-      {/each}
       </g>
     {/if}
 


### PR DESCRIPTION
Since match IDs can be null if they haven't happened yet, we should instead key on match table number

Before:

<img width="1302" height="874" alt="Screenshot 2025-10-19 at 9 03 10 AM" src="https://github.com/user-attachments/assets/01a5e76a-58bd-411b-88fe-6d53c592e586" />



After:

<img width="1188" height="861" alt="Screenshot 2025-10-19 at 9 03 26 AM" src="https://github.com/user-attachments/assets/af5b5f60-a4ba-4e42-a72e-5dd4a7715d32" />

