### PR TITLE
Update Rounds component for Svelte conversion

### DIFF
--- a/app/controllers/beta/pairings_controller.rb
+++ b/app/controllers/beta/pairings_controller.rb
@@ -18,7 +18,7 @@ module Beta
 
       save_report
 
-      render json: { url: tournament_rounds_path(@tournament) }, status: :ok
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
     end
 
     def reset_self_report
@@ -26,7 +26,37 @@ module Beta
 
       SelfReport.where(pairing_id: pairing.id).destroy_all
 
-      render json: { url: tournament_rounds_path(@tournament) }, status: :ok
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def save_report
+      pairing.update(score_params)
+
+      return unless score_params.key?('side') && pairing.reported?
+
+      score1_corp = pairing.score1_corp
+      pairing.score1_corp = pairing.score1_runner
+      pairing.score1_runner = score1_corp
+
+      score2_corp = pairing.score2_corp
+      pairing.score2_corp = pairing.score2_runner
+      pairing.score2_runner = score2_corp
+
+      pairing.save
+    end
+
+    def round
+      @round ||= Round.find(params[:round_id])
+    end
+
+    def pairing
+      @pairing ||= Pairing.find(params[:id])
+    end
+
+    def score_params
+      params.require(:pairing)
+            .permit(:score1_runner, :score1_corp, :score2_runner, :score2_corp,
+                    :score1, :score2, :side, :intentional_draw, :two_for_one)
     end
   end
 end

--- a/app/controllers/beta/stages_controller.rb
+++ b/app/controllers/beta/stages_controller.rb
@@ -2,12 +2,28 @@
 
 module Beta
   class StagesController < ApplicationController
+    before_action :set_tournament
+    before_action :set_stage, only: %i[destroy]
+
+    def create
+      authorize @tournament, :update?
+
+      stage = @tournament.stages.create(format: (@tournament.single_sided? ? :single_sided_swiss : :swiss))
+      @tournament.players.each { |p| stage.players << p }
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
     def destroy
       authorize @tournament, :update?
 
       @stage.destroy!
 
-      render json: { url: tournament_rounds_path(@tournament) }, status: :ok
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def set_stage
+      @stage = Stage.find(params[:id])
     end
   end
 end

--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Beta
+  class TournamentsController < ApplicationController
+    before_action :set_tournament, only: %i[
+      open_registration close_registration lock_player_registrations unlock_player_registrations
+      cut
+    ]
+
+    def open_registration
+      authorize @tournament, :edit?
+
+      @tournament.open_registration!
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def close_registration
+      authorize @tournament, :edit?
+
+      @tournament.close_registration!
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def lock_player_registrations
+      authorize @tournament, :edit?
+
+      @tournament.lock_player_registrations!
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def unlock_player_registrations
+      authorize @tournament, :edit?
+
+      @tournament.unlock_player_registrations!
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def cut
+      authorize @tournament
+
+      number = params[:number].to_i
+      format = params[:elimination_type] == 'single' ? :single_elim : :double_elim
+      return redirect_to standings_tournament_players_path(@tournament) unless [3, 4, 8, 16].include? number
+
+      @tournament.cut_to!(format, number)
+
+      render json: { url: beta_tournament_rounds_path(@tournament) }, status: :ok
+    end
+
+    def set_tournament
+      @tournament = Tournament.find(params[:id])
+    end
+  end
+end

--- a/app/frontend/pairings/AdminReportOptions.svelte
+++ b/app/frontend/pairings/AdminReportOptions.svelte
@@ -15,6 +15,10 @@
 
   let leftPlayer = $state(pairing.player1);
   let rightPlayer = $state(pairing.player2);
+  if (pairing.player2.side == "corp" && stage.is_single_sided) {
+    leftPlayer = pairing.player2;
+    rightPlayer = pairing.player1;
+  }
   let showScorePresets = $state(!pairing.reported);
   let customScore: ScoreReport = $state({
     score1: pairing.score1,

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -1,4 +1,5 @@
 import type { Identity } from "../identities/Identity";
+import { globalMessages } from "../utils/GlobalMessageState.svelte";
 import type { ScoreReport } from "./SelfReport";
 
 declare const Routes: {
@@ -24,7 +25,10 @@ export async function loadPairings(
     },
   );
 
-  return (await response.json()) as PairingsData;
+  const data = (await response.json()) as PairingsData;
+  globalMessages.warnings = data.warnings ?? [];
+
+  return data;
 }
 
 export async function loadSharingData(
@@ -41,11 +45,16 @@ export async function loadSharingData(
   return (await response.json()) as SharingData;
 }
 
-export interface PairingsData {
-  policy: TournamentPolicies;
-  tournament: Tournament;
-  is_player_meeting: boolean;
-  stages: Stage[];
+export class PairingsData {
+  policy = new TournamentPolicies();
+  tournament = new Tournament();
+  stages: Stage[] = [];
+  warnings?: string[] = [];
+}
+
+export class TournamentPolicies {
+  update = false;
+  custom_table_numbering = false;
 }
 
 export class SharingData {
@@ -54,11 +63,6 @@ export class SharingData {
   constructor() {
     this.pages = [];
   }
-}
-
-export interface TournamentPolicies {
-  update: boolean;
-  custom_table_numbering: boolean;
 }
 
 export class Tournament {

--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -1,49 +1,277 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Stage from "./Stage.svelte";
-  import type { PairingsData } from "./PairingsData";
-  import { loadPairings } from "./PairingsData";
+  import { loadPairings, PairingsData } from "./PairingsData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import { showIdentities } from "../utils/ShowIdentities";
+  import GlobalMessages from "../widgets/GlobalMessages.svelte";
+  import ModalDialog from "../widgets/ModalDialog.svelte";
+  import { showReportedPairings } from "../utils/ShowReportedPairings";
+  import { redirectRequest } from "../utils/network";
 
-  export let tournamentId: number;
-  let data: PairingsData;
+  let { tournamentId }: { tournamentId: number } = $props();
+
+  let data = $state(new PairingsData());
 
   onMount(async () => {
     data = await loadPairings(tournamentId);
   });
 
-  function toggleIdentities() {
-    showIdentities.update((value) => !value);
+  function addSwissStage() {
+    void redirectRequest(`/beta/tournaments/${tournamentId}/stages`, "POST");
+  }
+
+  function pairNewRound() {
+    if (
+      data.tournament.registration_unlocked &&
+      !confirm(
+        "Registration is still open or some players are unlocked. Pair new round anyway?",
+      )
+    ) {
+      return;
+    }
+
+    void redirectRequest(`/beta/tournaments/${tournamentId}/rounds`, "POST");
+  }
+
+  function closeRegistration() {
+    void redirectRequest(
+      `/beta/tournaments/${tournamentId}/close_registration`,
+      "PATCH",
+    );
+  }
+
+  function openRegistration() {
+    void redirectRequest(
+      `/beta/tournaments/${tournamentId}/open_registration`,
+      "PATCH",
+    );
+  }
+
+  function lockPlayerRegistration() {
+    void redirectRequest(
+      `/beta/tournaments/${tournamentId}/lock_player_registrations`,
+      "PATCH",
+    );
+  }
+
+  function unlockPlayerRegistration() {
+    void redirectRequest(
+      `/beta/tournaments/${tournamentId}/unlock_player_registrations`,
+      "PATCH",
+    );
+  }
+
+  function addCutStage(single_elim: boolean, num: number) {
+    void redirectRequest(`/beta/tournaments/${tournamentId}/cut`, "POST", {
+      number: num,
+      ...(single_elim && { elimination_type: "single" }),
+    });
   }
 </script>
 
-<button class="btn btn-primary" on:click={toggleIdentities}>
-  <FontAwesomeIcon icon="eye-slash" />
-  Show/hide identities
-</button>
+<GlobalMessages />
 
 <p></p>
 
 {#if data}
-  {#if data.is_player_meeting}
-    <p>
-      <a
-        href="/tournaments/{tournamentId}/players/meeting"
-        class="btn btn-primary"
-      >
-        <FontAwesomeIcon icon="list-ul" />
-        Player meeting
-      </a>
-    </p>
+  {#if data.stages.length == 0}
+    <!-- Add Swiss stage button -->
+    {#if data.policy.update}
+      <button type="button" class="btn btn-success" onclick={addSwissStage}>
+        <FontAwesomeIcon icon="plus" /> Add Swiss stage
+      </button>
+    {/if}
+  {:else}
+    <!-- Upper controls -->
+    <div>
+      {#if data.tournament.player_meeting}
+        <a
+          href="/tournaments/{tournamentId}/players/meeting"
+          class="btn btn-primary"
+        >
+          <FontAwesomeIcon icon="list-ul" /> Player meeting
+        </a>
+      {:else}
+        {#if data.policy.update}
+          <button
+            type="button"
+            class="btn btn-primary"
+            onclick={() => {
+              showReportedPairings.update((value) => !value);
+            }}
+          >
+            <FontAwesomeIcon icon="eye-slash" /> Show/hide reported pairings
+          </button>
+        {/if}
+        <button
+          type="button"
+          class="btn btn-primary"
+          onclick={() => {
+            showIdentities.update((value) => !value);
+          }}
+        >
+          <FontAwesomeIcon icon="eye-slash" /> Show/hide identities
+        </button>
+        <button
+          type="button"
+          class="btn btn-info"
+          data-toggle="modal"
+          data-target="#faq"
+        >
+          <FontAwesomeIcon icon="question" /> FAQ
+        </button>
+        {#if !$showReportedPairings}
+          <div class="alert alert-info mt-3">
+            Reported scores are currently hidden on this page. This will not
+            affect other users viewing this page.
+          </div>
+        {/if}
+      {/if}
+    </div>
+
+    <!-- Tournament admin controls -->
+    {#if data.policy.update}
+      <div class="mt-3">
+        {#if data.tournament.registration_open}
+          <button
+            type="button"
+            class="btn btn-info"
+            onclick={closeRegistration}
+          >
+            <FontAwesomeIcon icon="lock" /> Close registration
+          </button>
+        {:else if data.tournament.self_registration && data.stages.every((s) => s.rounds.length == 0)}
+          <button
+            type="button"
+            class="btn btn-secondary"
+            onclick={openRegistration}
+          >
+            <FontAwesomeIcon icon="folder-open" /> Open registration
+          </button>
+          {#if data.tournament.locked_players > 0}
+            <button
+              type="button"
+              class="btn btn-secondary"
+              onclick={unlockPlayerRegistration}
+            >
+              <FontAwesomeIcon icon="unlock" /> Unlock all players
+            </button>
+          {/if}
+          {#if data.tournament.unlocked_players > 0}
+            <button
+              type="button"
+              class="btn btn-info"
+              onclick={lockPlayerRegistration}
+            >
+              <FontAwesomeIcon icon="lock" /> Lock all players
+            </button>
+          {/if}
+        {/if}
+
+        {#if data.stages.every((s) => s.rounds.every((r) => r.completed))}
+          <button type="button" class="btn btn-success" onclick={pairNewRound}>
+            <FontAwesomeIcon icon="plus" /> Pair new round!
+          </button>
+        {:else}
+          <button class="btn btn-secondary disabled">
+            <FontAwesomeIcon icon="plus" /> Pair new round!
+          </button>
+          <span class="ml-2">
+            All rounds must be flagged complete before you can add a new round.
+          </span>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Stages -->
+    <div class="mt-3">
+      {#each data.stages as stage, index (stage.format)}
+        <Stage
+          {stage}
+          startExpanded={index === data.stages.length - 1}
+          tournament={data.tournament}
+          tournamentPolicies={data.policy}
+        />
+      {/each}
+    </div>
+
+    <!-- Elimination stage controls -->
+    {#if data.policy.update && data.stages.length > 0 && !data.stages[data.stages.length - 1].is_elimination}
+      <h4>Cut to...</h4>
+      <table>
+        <tbody>
+          <tr>
+            <td>Single Elimination</td>
+            {#each [3, 4, 8, 16] as num (num)}
+              <td class="pl-2">
+                <button
+                  type="button"
+                  class="btn btn-success"
+                  onclick={() => {
+                    addCutStage(true, num);
+                  }}
+                >
+                  <FontAwesomeIcon icon="scissors" /> Top {num}
+                </button>
+              </td>
+            {/each}
+          </tr>
+          <tr>
+            <td>Double Elimination</td>
+            <td></td>
+            {#each [4, 8, 16] as num (num)}
+              <td class="pt-2 pl-2">
+                <button
+                  type="button"
+                  class="btn btn-success"
+                  onclick={() => {
+                    addCutStage(false, num);
+                  }}
+                >
+                  <FontAwesomeIcon icon="scissors" /> Top {num}
+                </button>
+              </td>
+            {/each}
+          </tr>
+        </tbody>
+      </table>
+    {/if}
+
+    <!-- FAQ dialog -->
+    <ModalDialog id="faq" headerText="FAQ">
+      <h5>How does self reporting work?</h5>
+      <ul>
+        <li>
+          For self reporting, a player needs to be logged in with the NRDB
+          account they used to register for the tournament to ensure they are
+          reporting only their games.
+        </li>
+        <li>
+          Self reporting in Cobra works alongside the
+          <span class="font-weight-bold">two-eye principle</span>: both players
+          have to report the same result for Cobra to accept the answer and set
+          the scores.
+        </li>
+      </ul>
+      <h5>Does self reporting replace normal reports?</h5>
+      <p>
+        No, it just allows players to report their own scores instead of handing
+        in manually. This should ease the overall reporting process.
+      </p>
+      <ul>
+        <li>
+          The TO can monitor any reports by clicking on
+          <span class="font-weight-bold">'Reports'</span>
+          which shows the scores reported.
+        </li>
+        <li>
+          The TO can accept a single report by clicking on the provided option.
+        </li>
+        <li>As always, the TO can report games as normal.</li>
+      </ul>
+    </ModalDialog>
   {/if}
-  {#each data.stages as stage, index (stage.format)}
-    <Stage
-      {stage}
-      startExpanded={index === data.stages.length - 1}
-      tournament={data.tournament}
-    />
-  {/each}
 {:else}
   <div class="d-flex align-items-center m-2">
     <div class="spinner-border m-auto"></div>

--- a/app/frontend/utils/ShowIdentities.ts
+++ b/app/frontend/utils/ShowIdentities.ts
@@ -5,5 +5,5 @@ const initialValue: boolean = JSON.parse(
 ) as boolean;
 export const showIdentities = writable(initialValue);
 showIdentities.subscribe(
-  (value) => (localStorage.show_identities = JSON.stringify(value)),
+  (value) => (localStorage.showIdentities = JSON.stringify(value)),
 );

--- a/app/frontend/widgets/GlobalMessages.svelte
+++ b/app/frontend/widgets/GlobalMessages.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { globalMessages } from "../utils/GlobalMessageState.svelte";
+</script>
+
+<div>
+  {#each globalMessages.infos as info (info)}
+    {#if info}
+      <div class="alert alert-info">{info}</div>
+    {/if}
+  {/each}
+
+  {#each globalMessages.warnings as warning (warning)}
+    {#if warning}
+      <div class="alert alert-warning">{warning}</div>
+    {/if}
+  {/each}
+
+  {#each globalMessages.errors as error (error)}
+    {#if error}
+      <div class="alert alert-danger">{error}</div>
+    {/if}
+  {/each}
+</div>

--- a/app/views/beta/rounds/index.html.slim
+++ b/app/views/beta/rounds/index.html.slim
@@ -1,0 +1,4 @@
+#rounds_anchor.col-12 data-tournament="#{@tournament.id}"
+
+= content_for :head do
+  = vite_typescript_tag 'rounds', 'data-turbolinks-track': 'reload'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   namespace :beta do
     resources :tournaments do
-      resources :rounds, only: %i[index] do
+      resources :rounds, only: %i[index create] do
         resources :pairings, only: %i[destroy] do
           post :report, on: :member
           delete :reset_self_report, on: :member
@@ -30,8 +30,12 @@ Rails.application.routes.draw do
         patch :complete, on: :member
         patch :update_timer, on: :member
       end
-      resources :stages, only: %i[destroy] do
-      end
+      resources :stages, only: %i[create destroy]
+      patch :open_registration, on: :member
+      patch :close_registration, on: :member
+      patch :lock_player_registrations, on: :member
+      patch :unlock_player_registrations, on: :member
+      post :cut, on: :member
     end
   end
 

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-            'is_player_meeting' => true,
-            'policy' => { 'update' => false },
+            'policy' => { 'custom_table_numbering' => false, 'update' => false },
             'tournament' =>
             {
               'id' => tournament.id,
@@ -28,7 +27,8 @@ RSpec.describe RoundsController do
               'unlocked_players' => 3,
               'allow_streaming_opt_out' => nil
             },
-            'stages' => [swiss_stage_with_rounds([])]
+            'stages' => [swiss_stage_with_rounds([])],
+            'warnings' => nil
           )
       end
 
@@ -38,8 +38,7 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-            'is_player_meeting' => true,
-            'policy' => { 'update' => false },
+            'policy' => { 'custom_table_numbering' => false, 'update' => false },
             'tournament' =>
             {
               'id' => tournament.id,
@@ -51,7 +50,8 @@ RSpec.describe RoundsController do
               'unlocked_players' => 3,
               'allow_streaming_opt_out' => nil
             },
-            'stages' => [swiss_stage_with_rounds([])]
+            'stages' => [swiss_stage_with_rounds([])],
+            'warnings' => nil
           )
       end
 
@@ -61,8 +61,7 @@ RSpec.describe RoundsController do
 
         expect(compare_body(response))
           .to eq(
-            'is_player_meeting' => true,
-            'policy' => { 'update' => true },
+            'policy' => { 'custom_table_numbering' => false, 'update' => true },
             'tournament' =>
             {
               'id' => tournament.id,
@@ -74,7 +73,8 @@ RSpec.describe RoundsController do
               'unlocked_players' => 3,
               'allow_streaming_opt_out' => nil
             },
-            'stages' => [swiss_stage_with_rounds([])]
+            'stages' => [swiss_stage_with_rounds([])],
+            'warnings' => [nil]
           )
       end
     end
@@ -89,8 +89,7 @@ RSpec.describe RoundsController do
         get pairings_data_tournament_rounds_path(tournament)
         expect(compare_body(response))
           .to eq({
-                   'is_player_meeting' => false,
-                   'policy' => { 'update' => false },
+                   'policy' => { 'custom_table_numbering' => false, 'update' => false },
                    'tournament' =>
                    {
                      'id' => tournament.id,
@@ -111,29 +110,31 @@ RSpec.describe RoundsController do
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Charlie (she/her)'),
                              'player2' => player_with_no_ids('Bob (he/him)'),
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => false,
+                             'score1' => nil,
+                             'score2' => nil,
                              'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 6,
+                             'score2' => 0,
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                          ],
                          'pairings_reported' => 1,
                          'length_minutes' => 65,
-                         'timer' =>
-                         {
-                           'running' => false,
-                           'paused' => false,
-                           'started' => false
-                         }
+                         'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                        }
                      ]
-                   )]
+                   )],
+                   'warnings' => nil
                  })
       end
 
@@ -142,8 +143,7 @@ RSpec.describe RoundsController do
         get pairings_data_tournament_rounds_path(tournament)
         expect(compare_body(response))
           .to eq({
-                   'is_player_meeting' => false,
-                   'policy' => { 'update' => true },
+                   'policy' => { 'custom_table_numbering' => false, 'update' => true },
                    'tournament' =>
                    {
                      'id' => tournament.id,
@@ -164,35 +164,31 @@ RSpec.describe RoundsController do
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Charlie (she/her)'),
                              'player2' => player_with_no_ids('Bob (he/him)'),
-                             'policy' => {
-                               'view_decks' => false,
-                               'self_report' => false
-                             }, # sees player view as a player
+                             'policy' => { 'self_report' => false }, # sees player view as a player
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => false,
+                             'score1' => nil,
+                             'score2' => nil,
                              'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
-                             'policy' => {
-                               'view_decks' => false,
-                               'self_report' => false
-                             }, # sees player view as a player
+                             'policy' => { 'self_report' => false }, # sees player view as a player
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 6,
+                             'score2' => 0,
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                          ],
                          'pairings_reported' => 1,
                          'length_minutes' => 65,
-                         'timer' =>
-                         {
-                           'running' => false,
-                           'paused' => false,
-                           'started' => false
-                         }
+                         'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                        }
                      ]
-                   )]
+                   )],
+                   'warnings' => [nil]
                  })
       end
     end
@@ -209,8 +205,7 @@ RSpec.describe RoundsController do
         get pairings_data_tournament_rounds_path(tournament)
         expect(compare_body(response))
           .to eq({
-                   'is_player_meeting' => false,
-                   'policy' => { 'update' => false },
+                   'policy' => { 'custom_table_numbering' => false, 'update' => false },
                    'tournament' =>
                    {
                      'id' => tournament.id,
@@ -232,26 +227,27 @@ RSpec.describe RoundsController do
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Charlie (she/her)'),
                                'player2' => player_with_no_ids('Bob (he/him)'),
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => false,
+                               'score1' => nil,
+                               'score2' => nil,
                                'score_label' => ' - ', 'two_for_one' => false,
-                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                               'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Alice (she/her)'),
                                'player2' => bye_player,
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => true,
+                               'score1' => 6,
+                               'score2' => 0,
                                'score_label' => '6 - 0', 'two_for_one' => false,
-                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                               'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                            ],
                            'pairings_reported' => 1,
                            'length_minutes' => 65,
-                           'timer' =>
-                           {
-                             'running' => false,
-                             'paused' => false,
-                             'started' => false
-                           }
+                           'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                          }
                        ]
                      ),
@@ -264,23 +260,22 @@ RSpec.describe RoundsController do
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Bob (he/him)'),
                                'player2' => player_with_no_ids('Charlie (she/her)'),
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => false,
+                               'score1' => nil,
+                               'score2' => nil,
                                'score_label' => ' - ', 'two_for_one' => false,
-                               'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil }
+                               'table_label' => 'Game 1', 'table_number' => 1, 'self_reports' => nil }
                            ],
                            'pairings_reported' => 0,
                            'length_minutes' => 40,
-                           'timer' =>
-                           {
-                             'running' => false,
-                             'paused' => false,
-                             'started' => false
-                           }
+                           'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                          }
                        ]
                      )
-                   ]
+                   ],
+                   'warnings' => nil
                  })
       end
 
@@ -299,26 +294,27 @@ RSpec.describe RoundsController do
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Charlie (she/her)'),
                                'player2' => player_with_no_ids('Bob (he/him)'),
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => false,
+                               'score1' => nil,
+                               'score2' => nil,
                                'score_label' => ' - ', 'two_for_one' => false,
-                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                               'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Alice (she/her)'),
                                'player2' => bye_player,
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => true,
+                               'score1' => 6,
+                               'score2' => 0,
                                'score_label' => '6 - 0', 'two_for_one' => false,
-                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                               'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                            ],
                            'pairings_reported' => 1,
                            'length_minutes' => 65,
-                           'timer' =>
-                           {
-                             'running' => false,
-                             'paused' => false,
-                             'started' => false
-                           }
+                           'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                          }
                        ]
                      ),
@@ -331,20 +327,18 @@ RSpec.describe RoundsController do
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Bob (he/him)'),
                                'player2' => player_with_no_ids('Charlie (she/her)'),
-                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
+                               'reported' => false,
+                               'score1' => nil,
+                               'score2' => nil,
                                'score_label' => ' - ', 'two_for_one' => false,
-                               'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil,
+                               'table_label' => 'Game 1', 'table_number' => 1, 'self_reports' => nil,
                                'round' => 1, 'winner_game' => 2, 'loser_game' => nil, 'bracket_type' => 'upper' }
                            ],
                            'pairings_reported' => 0,
                            'length_minutes' => 40,
-                           'timer' =>
-                           {
-                             'running' => false,
-                             'paused' => false,
-                             'started' => false
-                           }
+                           'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                          },
                          {
                            'number' => 2,
@@ -375,8 +369,7 @@ RSpec.describe RoundsController do
         get pairings_data_tournament_rounds_path(tournament)
         expect(compare_body(response))
           .to eq({
-                   'is_player_meeting' => false,
-                   'policy' => { 'update' => false },
+                   'policy' => { 'custom_table_numbering' => false, 'update' => false },
                    'tournament' =>
                    {
                      'id' => tournament.id,
@@ -397,29 +390,31 @@ RSpec.describe RoundsController do
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Charlie (she/her)', side: 'corp', side_label: '(Corp)'),
                              'player2' => player_with_no_ids('Bob (he/him)', side: 'runner', side_label: '(Runner)'),
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 3,
+                             'score2' => 0,
                              'score_label' => '3 - 0 (C)', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 6,
+                             'score2' => 0,
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                          ],
                          'pairings_reported' => 2,
                          'length_minutes' => 65,
-                         'timer' =>
-                         {
-                           'running' => false,
-                           'paused' => false,
-                           'started' => false
-                         }
+                         'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                        }
                      ]
-                   )]
+                   )],
+                   'warnings' => nil
                  })
       end
     end
@@ -439,8 +434,7 @@ RSpec.describe RoundsController do
         get pairings_data_tournament_rounds_path(tournament)
         expect(compare_body(response))
           .to eq({
-                   'is_player_meeting' => false,
-                   'policy' => { 'update' => false },
+                   'policy' => { 'custom_table_numbering' => false, 'update' => false },
                    'tournament' =>
                    {
                      'id' => tournament.id,
@@ -463,29 +457,31 @@ RSpec.describe RoundsController do
                                'Charlie (she/her)', side: 'runner', side_label: '(Runner)'
                              ),
                              'player2' => player_with_no_ids('Bob (he/him)', side: 'corp', side_label: '(Corp)'),
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 3,
+                             'score2' => 0,
                              'score_label' => '0 - 3 (R)', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_reports' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
-                             'policy' => { 'view_decks' => false, 'self_report' => false },
+                             'policy' => { 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
+                             'reported' => true,
+                             'score1' => 6,
+                             'score2' => 0,
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_reports' => nil }
                          ],
                          'pairings_reported' => 2,
                          'length_minutes' => 65,
-                         'timer' =>
-                         {
-                           'running' => false,
-                           'paused' => false,
-                           'started' => false
-                         }
+                         'timer' => { 'running' => false, 'paused' => false, 'started' => false }
                        }
                      ]
-                   )]
+                   )],
+                   'warnings' => nil
                  })
       end
     end
@@ -530,6 +526,7 @@ RSpec.describe RoundsController do
       'is_single_sided' => false,
       'is_elimination' => false,
       'rounds' => rounds,
+      'view_decks' => false,
       'player_count' => 3
     }
   end
@@ -541,6 +538,7 @@ RSpec.describe RoundsController do
       'is_single_sided' => true,
       'is_elimination' => true,
       'rounds' => rounds,
+      'view_decks' => false,
       'player_count' => 3
     }
   end


### PR DESCRIPTION
This is a subset of PR #657 focused on just the changes to the `Rounds` component and everything required to make that work. This also incorporates some of the review suggestions made in that PR.

This is the PR that finally makes the work in the previous PRs accessible. The `Rounds` component is the top-most component on the Pairings tab, so everything in the previous PRs should now be accessible to TOs when visiting the page through the /beta path (e.g. /beta/tournaments/1/rounds). The player view of this page and components should not be noticeably different.