### PR TITLE
Fix for erroneous beta links appearing when the beta is disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
     return '/' if path.blank?
 
     new_path = path
-    if cookies[:beta_enabled] == 'false'
+    if !cookies.key?(:key) || cookies[:beta_enabled] == 'false'
       new_path.delete_prefix!('/beta')
     elsif !new_path.start_with?('/beta') && BETA_PATHS.any? { |r| new_path =~ r }
       new_path.prepend('/beta')


### PR DESCRIPTION
I missed checking for the case when the user doesn't have the `beta_enabled` cookie.