### PR TITLE
Write logs to local log folder, not container.

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,6 +26,9 @@ services:
     expose:
       - "3000"
 
+    volumes:
+      - ./log:/var/www/cobra/log
+
 networks:
   backend:
   null_signal:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -26,6 +26,9 @@ services:
     expose:
       - "3000"
 
+    volumes:
+      - ./log:/var/www/cobra/log
+
 networks:
   backend:
   null_signal:


### PR DESCRIPTION
this will let us set up log rotation and some other things a little more easily as well.