### PR TITLE
Identity autocomplete in Svelte

### DIFF
--- a/app/controllers/beta/identities_controller.rb
+++ b/app/controllers/beta/identities_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Beta
+  class IdentitiesController < ApplicationController
+    include IdentitiesHelper
+
+    def index
+      skip_authorization
+
+      render json: {
+        corp: Identity.where(side: :corp).map { |id| autocomplete_hash(id) }.uniq { |id| id[:label] },
+        runner: Identity.where(side: :runner).map { |id| autocomplete_hash(id) }.uniq { |id| id[:label] }
+      }
+    end
+  end
+end

--- a/app/frontend/identities/Identity.ts
+++ b/app/frontend/identities/Identity.ts
@@ -1,3 +1,28 @@
+declare const Routes: {
+  beta_identities_path: () => string;
+}
+
+export async function loadIdentityNames() {
+  const response = await fetch(
+    Routes.beta_identities_path(),
+    {
+      method: "GET",
+    },
+  );
+
+  return (await response.json()) as IdentityNames;
+}
+
+export interface IdentityName {
+  label: string;
+  value: string;
+}
+
+export interface IdentityNames {
+  corp: IdentityName[];
+  runner: IdentityName[];
+}
+
 export class Identity {
   name = "";
   faction: string | null = null;

--- a/app/frontend/identities/Identity.ts
+++ b/app/frontend/identities/Identity.ts
@@ -1,14 +1,11 @@
 declare const Routes: {
   beta_identities_path: () => string;
-}
+};
 
 export async function loadIdentityNames() {
-  const response = await fetch(
-    Routes.beta_identities_path(),
-    {
-      method: "GET",
-    },
-  );
+  const response = await fetch(Routes.beta_identities_path(), {
+    method: "GET",
+  });
 
   return (await response.json()) as IdentityNames;
 }

--- a/app/frontend/players/PlayerForm.svelte
+++ b/app/frontend/players/PlayerForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { IdentityNames } from "../identities/Identity";
   import type { TournamentPolicies } from "../pairings/PairingsData";
   import type { Tournament } from "../tournaments/TournamentSettings";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
@@ -10,11 +11,13 @@
     togglePlayerLock as togglePlayerLockRequest,
     dropPlayer as dropPlayerRequest,
   } from "./PlayersData";
+  import IdentitySelect from "../widgets/IdentitySelect.svelte";
 
   let {
     player,
     tournament,
     tournamentPolicies,
+    identityNames,
     savedCallback,
     droppedCallback,
     deletedCallback,
@@ -22,6 +25,7 @@
     player: Player;
     tournament: Tournament;
     tournamentPolicies: TournamentPolicies;
+    identityNames: IdentityNames;
     savedCallback?: (player: Player) => void;
     droppedCallback?: (player: Player) => void;
     deletedCallback?: (player: Player) => void;
@@ -99,7 +103,7 @@
   </div>
 
   <!-- Pronouns -->
-  <div class="col-auto">
+  <div class="col">
     <label for="player_pronouns_{playerEdit.id}">Pronouns</label>
     <input
       id="player_pronouns_{playerEdit.id}"
@@ -112,27 +116,25 @@
 
   {#if !tournament.nrdb_deck_registration || playerEdit.id !== 0}
     <!-- Corp ID -->
-    <div class="col">
+    <div class="col w-25">
       <label for="player_corp_id_{playerEdit.id}">Corp ID</label>
-      <input
+      <IdentitySelect
         id="player_corp_id_{playerEdit.id}"
-        type="text"
-        class="form-control corp_identities"
         placeholder="Search for corp ID"
-        readonly={tournament.nrdb_deck_registration}
+        enabled={!tournament.nrdb_deck_registration}
+        identityNames={identityNames.corp}
         bind:value={playerEdit.corp_id.name}
       />
     </div>
 
     <!-- Runner ID -->
-    <div class="col">
+    <div class="col w-25">
       <label for="player_runner_id_{playerEdit.id}">Runner ID</label>
-      <input
+      <IdentitySelect
         id="player_runner_id_{playerEdit.id}"
-        type="text"
-        class="form-control runner_identities"
         placeholder="Search for runner ID"
-        readonly={tournament.nrdb_deck_registration}
+        enabled={!tournament.nrdb_deck_registration}
+        identityNames={identityNames.runner}
         bind:value={playerEdit.runner_id.name}
       />
     </div>

--- a/app/frontend/players/Players.svelte
+++ b/app/frontend/players/Players.svelte
@@ -21,10 +21,15 @@
   } from "../tournaments/TournamentSettings";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import { downloadBlob, quoteCsvValue } from "../utils/files";
+  import {
+    loadIdentityNames,
+    type IdentityNames,
+  } from "../identities/Identity";
 
   let { tournamentId }: { tournamentId: number } = $props();
 
   let data: PlayersData | undefined = $state();
+  let identityNames: IdentityNames | undefined = $state();
   let newPlayer = $state(new Player());
   let registrationLockDescription = $derived.by(() => {
     if (!data) {
@@ -57,6 +62,7 @@
 
   onMount(async () => {
     await loadData();
+    identityNames = await loadIdentityNames();
   });
 
   async function loadData() {
@@ -260,6 +266,7 @@
       player={newPlayer}
       tournament={data.tournament}
       tournamentPolicies={data.tournamentPolicies}
+      identityNames={identityNames ?? { corp: [], runner: [] }}
       savedCallback={newPlayerSavedCallback}
     />
   </div>
@@ -425,6 +432,7 @@
           {player}
           tournament={data.tournament}
           tournamentPolicies={data.tournamentPolicies}
+          identityNames={identityNames ?? { corp: [], runner: [] }}
           savedCallback={loadData}
           droppedCallback={loadData}
           deletedCallback={loadData}

--- a/app/frontend/tests/Players.svelte-test.ts
+++ b/app/frontend/tests/Players.svelte-test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MockIdentityNames,
   MockPlayerAlice,
   MockPlayerBob,
   MockPlayersData,
@@ -11,6 +12,7 @@ import {
   getByRole,
   render,
   screen,
+  waitFor,
 } from "@testing-library/svelte";
 import { userEvent } from "@testing-library/user-event";
 import {
@@ -32,6 +34,7 @@ import {
   deckVisibilityString,
   SwissDeckVisibility,
 } from "../tournaments/TournamentSettings";
+import { loadIdentityNames } from "../identities/Identity";
 
 const user = userEvent.setup();
 
@@ -52,15 +55,37 @@ vi.mock("../players/PlayersData", async (importOriginal) => ({
   reinstatePlayer: vi.fn(() => true),
 }));
 
+vi.mock("../identities/Identity", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../identities/Identity")>()),
+  loadIdentityNames: vi.fn(() => MockIdentityNames),
+}));
+
 describe("Players", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
   });
 
   describe("when there are no dropped players", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       render(Players, { tournamentId: 1 });
-      expect(loadPlayers).toHaveBeenCalledOnce();
+      await waitFor(() => {
+        expect(loadPlayers).toHaveBeenCalledOnce();
+      });
+      await waitFor(() => {
+        expect(loadIdentityNames).toHaveBeenCalledOnce();
+      });
     });
 
     it("displays active players", () => {
@@ -69,12 +94,12 @@ describe("Players", () => {
       expect(playerItems).toHaveLength(2);
       expect(getByLabelText(playerItems[0], "Name")).toHaveValue("Alice");
       expect(getByLabelText(playerItems[0], "Pronouns")).toHaveValue("she/her");
-      expect(getByLabelText(playerItems[0], "Corp ID")).toHaveValue(
-        "A Teia: IP Recovery",
-      );
-      expect(getByLabelText(playerItems[0], "Runner ID")).toHaveValue(
-        "Arissana Rocha Nahu: Street Artist",
-      );
+      expect(
+        playerItems[0].querySelector('select[name="player_corp_id_1"]'),
+      ).toHaveValue("A Teia: IP Recovery");
+      expect(
+        playerItems[0].querySelector('select[name="player_runner_id_1"]'),
+      ).toHaveValue("Arissana Rocha Nahu: Street Artist");
       expect(
         getByRole(playerItems[0], "checkbox", {
           name: "Video coverage allowed",
@@ -88,12 +113,12 @@ describe("Players", () => {
       );
       expect(getByLabelText(playerItems[1], "Name")).toHaveValue("Bob");
       expect(getByLabelText(playerItems[1], "Pronouns")).toHaveValue("he/him");
-      expect(getByLabelText(playerItems[1], "Corp ID")).toHaveValue(
-        "BANGUN: When Disaster Strikes",
-      );
-      expect(getByLabelText(playerItems[1], "Runner ID")).toHaveValue(
-        "Barry “Baz” Wong: Tri-Maf Veteran",
-      );
+      expect(
+        playerItems[1].querySelector('select[name="player_corp_id_2"]'),
+      ).toHaveValue("BANGUN: When Disaster Strikes");
+      expect(
+        playerItems[1].querySelector('select[name="player_runner_id_2"]'),
+      ).toHaveValue("Barry “Baz” Wong: Tri-Maf Veteran");
       expect(
         getByRole(playerItems[1], "checkbox", {
           name: "Video coverage allowed",

--- a/app/frontend/tests/PlayersTestData.ts
+++ b/app/frontend/tests/PlayersTestData.ts
@@ -1,3 +1,4 @@
+import type { IdentityNames } from "../identities/Identity";
 import type { Player, PlayersData } from "../players/PlayersData";
 import { Tournament } from "../tournaments/TournamentSettings";
 
@@ -67,4 +68,27 @@ export const MockPlayersData: PlayersData = {
   },
   activePlayers: [MockPlayerAlice, MockPlayerBob],
   droppedPlayers: [],
+};
+
+export const MockIdentityNames: IdentityNames = {
+  corp: [
+    {
+      label: "A Teia: IP Recovery",
+      value: "A Teia: IP Recovery",
+    },
+    {
+      label: "BANGUN: When Disaster Strikes",
+      value: "BANGUN: When Disaster Strikes",
+    },
+  ],
+  runner: [
+    {
+      label: "Arissana Rocha Nahu: Street Artist",
+      value: "Arissana Rocha Nahu: Street Artist",
+    },
+    {
+      label: "Barry “Baz” Wong: Tri-Maf Veteran",
+      value: "Barry “Baz” Wong: Tri-Maf Veteran",
+    },
+  ],
 };

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -5,6 +5,8 @@
   import { Player, savePlayer } from "../players/PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import Identity from "../identities/Identity.svelte";
+  import { loadIdentityNames, type IdentityName, type IdentityNames } from "../identities/Identity";
+  import Svelecte from "svelecte";
 
   let {
     tournamentId,
@@ -17,13 +19,15 @@
   } = $props();
 
   let tournament: Tournament | undefined = $state();
-  let notices: string[] = $state([]);
   let player: Player | undefined = $state();
+  let identityNames: IdentityNames | undefined = $state();
+  let notices: string[] = $state([]);
   let playerAgreed = $state(false);
 
   onMount(async () => {
     tournament = await loadTournament(tournamentId);
     player = await loadPlayer(tournamentId, userId);
+    identityNames = await loadIdentityNames();
 
     if (player.id === 0) {
       player.name = userName ?? "";
@@ -44,6 +48,18 @@
       }
     }
   });
+
+  function corpIdChanged(selected: IdentityName | null) {
+    if (player && selected) {
+      player.corp_id.name = selected.value;
+    }
+  }
+
+  function runnerIdChanged(selected: IdentityName | null) {
+    if (player && selected) {
+      player.runner_id.name = selected.value;
+    }
+  }
 
   async function register() {
     if (!player) {
@@ -251,26 +267,28 @@
 
                   {#if !tournament.nrdb_deck_registration}
                     <div class="form-group">
-                      <label class="d-block" for="corp_identity">Corp ID</label>
-                      <input
-                        id="corp_identity"
-                        type="text"
+                      <label class="d-block" for="corp-identity">Corp ID</label>
+                      <Svelecte
+                        inputId="corp-identity"
                         placeholder="Search for corp ID"
-                        class="form-control corp_identities"
-                        bind:value={player.corp_id.name}
+                        options={identityNames ? identityNames.corp : []}
+                        labelField="value"
+                        valueField="label"
+                        onChange={corpIdChanged}
                       />
                     </div>
 
                     <div class="form-group">
-                      <label class="d-block" for="runner_identity">
+                      <label class="d-block" for="runner-identity">
                         Runner ID
                       </label>
-                      <input
-                        id="runner_identity"
-                        type="text"
+                      <Svelecte
+                        inputId="runner-identity"
                         placeholder="Search for runner ID"
-                        class="form-control runner_identities"
-                        bind:value={player.runner_id.name}
+                        options={identityNames ? identityNames.runner : []}
+                        labelField="value"
+                        valueField="label"
+                        onChange={runnerIdChanged}
                       />
                     </div>
                   {/if}

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -5,8 +5,11 @@
   import { Player, savePlayer } from "../players/PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import Identity from "../identities/Identity.svelte";
-  import { loadIdentityNames, type IdentityName, type IdentityNames } from "../identities/Identity";
-  import Svelecte from "svelecte";
+  import {
+    loadIdentityNames,
+    type IdentityNames,
+  } from "../identities/Identity";
+  import IdentitySelect from "../widgets/IdentitySelect.svelte";
 
   let {
     tournamentId,
@@ -48,18 +51,6 @@
       }
     }
   });
-
-  function corpIdChanged(selected: IdentityName | null) {
-    if (player && selected) {
-      player.corp_id.name = selected.value;
-    }
-  }
-
-  function runnerIdChanged(selected: IdentityName | null) {
-    if (player && selected) {
-      player.runner_id.name = selected.value;
-    }
-  }
 
   async function register() {
     if (!player) {
@@ -268,13 +259,11 @@
                   {#if !tournament.nrdb_deck_registration}
                     <div class="form-group">
                       <label class="d-block" for="corp-identity">Corp ID</label>
-                      <Svelecte
-                        inputId="corp-identity"
+                      <IdentitySelect
+                        id="corp-identity"
                         placeholder="Search for corp ID"
-                        options={identityNames ? identityNames.corp : []}
-                        labelField="value"
-                        valueField="label"
-                        onChange={corpIdChanged}
+                        identityNames={identityNames ? identityNames.corp : []}
+                        bind:value={player.corp_id.name}
                       />
                     </div>
 
@@ -282,13 +271,13 @@
                       <label class="d-block" for="runner-identity">
                         Runner ID
                       </label>
-                      <Svelecte
-                        inputId="runner-identity"
+                      <IdentitySelect
+                        id="corp-identity"
                         placeholder="Search for runner ID"
-                        options={identityNames ? identityNames.runner : []}
-                        labelField="value"
-                        valueField="label"
-                        onChange={runnerIdChanged}
+                        identityNames={identityNames
+                          ? identityNames.runner
+                          : []}
+                        bind:value={player.runner_id.name}
                       />
                     </div>
                   {/if}

--- a/app/frontend/widgets/IdentitySelect.svelte
+++ b/app/frontend/widgets/IdentitySelect.svelte
@@ -32,6 +32,7 @@
 </script>
 
 <Svelecte
+  name={id}
   inputId={id}
   controlClass={cssClass}
   disabled={!enabled}

--- a/app/frontend/widgets/IdentitySelect.svelte
+++ b/app/frontend/widgets/IdentitySelect.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import Svelecte from "svelecte";
+  import type { IdentityName } from "../identities/Identity";
+
+  let {
+    id,
+    identityNames,
+    value = $bindable(),
+    cssClass = "",
+    placeholder = "Search for ID",
+    enabled = true,
+  }: {
+    id: string;
+    identityNames: IdentityName[];
+    value?: string;
+    cssClass?: string;
+    placeholder?: string;
+    enabled?: boolean;
+  } = $props();
+
+  let selectedValue = $derived.by(() => {
+    const id = identityNames.find((id) => id.value === value);
+    return id ? id.label : null;
+  });
+
+  // We save the display name instead of the searchable text so we need to
+  // manually set the value since we can't bind to the display text with
+  // Svelecte.
+  function idChanged(selected: IdentityName | null) {
+    value = selected ? selected.value : "";
+  }
+</script>
+
+<Svelecte
+  inputId={id}
+  controlClass={cssClass}
+  disabled={!enabled}
+  {placeholder}
+  options={identityNames}
+  labelField="value"
+  valueField="label"
+  bind:value={selectedValue}
+  onChange={idChanged}
+/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       get :id_and_faction_data, on: :member
       get :cut_conversion_rates, on: :member
     end
+    resources :identities, only: [:index]
     get :help
   end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "msw": "^2.10.2",
         "prettier": "^3.5.3",
         "prettier-plugin-svelte": "^3.3.3",
+        "svelecte": "^5.3.0",
         "svelte": "^5.53.6",
         "svelte-check": "^4.1.5",
         "tslib": "^2.8.1",
@@ -4400,6 +4401,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svelecte": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/svelecte/-/svelecte-5.3.0.tgz",
+      "integrity": "sha512-9WKD6KxPf31CweyZtObTetGtkq1TncBA2E+aSHcT+bfjALgP+LUGMMQUU+2qhlfSoGpw9JYmLfxphGjb0q350g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": "^5.2.7"
       }
     },
     "node_modules/svelte": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "msw": "^2.10.2",
     "prettier": "^3.5.3",
     "prettier-plugin-svelte": "^3.3.3",
+    "svelecte": "^5.3.0",
     "svelte": "^5.53.6",
     "svelte-check": "^4.1.5",
     "tslib": "^2.8.1",


### PR DESCRIPTION
These changes implement identity autocomplete using the [Svelecte](https://svelecte.vercel.app/), a Svelte-native selection widget.

Svelecte performs the autocompletion search on your input's value field (i.e. non-display field) and assumes that this is the value you need to save. However, we save the display value to the database, so I created the `IdentitySelect` widget to:
1. Keep the concept of "label" and "value" fields consistent between our model and theirs.
2. Return the ID's display value (i.e. the one with fancy characters) when an option is selected.