### PR TITLE
Tournament QR code Svelte conversion

### DIFF
--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -3,7 +3,7 @@
 module Beta
   class TournamentsController < ApplicationController # rubocop:disable Metrics/ClassLength,Style/Documentation
     before_action :set_tournament, only: %i[
-      show update open_registration close_registration lock_player_registrations unlock_player_registrations
+      show update qr open_registration close_registration lock_player_registrations unlock_player_registrations
       cut stats id_and_faction_data cut_conversion_rates
     ]
     before_action :authorize_beta_testing
@@ -64,6 +64,15 @@ module Beta
           end
         end
       end
+    end
+
+    def qr
+      authorize @tournament, :show?
+
+      send_data(RQRCode::QRCode.new(tournament_url(@tournament.slug, request), level: :h)
+                               .as_svg(offset: 0, color: '000', shape_rendering: 'crispEdges', module_size: 25),
+                type: 'image/svg+xml',
+                disposition: 'inline')
     end
 
     def open_registration
@@ -144,6 +153,12 @@ module Beta
         # Used for demo tournaments
         :num_players, :num_first_round_byes
       )
+    end
+
+    def tournament_url(slug, request)
+      server = "#{request.protocol}#{request.host}"
+      server += ":#{request.port}" if !request.port.nil? && (request.port != 80) && (request.port != 443)
+      "#{server}/#{slug.downcase}"
     end
 
     def transform_stats(stats)

--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -158,7 +158,7 @@ module Beta
     def tournament_url(slug, request)
       server = "#{request.protocol}#{request.host}"
       server += ":#{request.port}" if !request.port.nil? && (request.port != 80) && (request.port != 443)
-      "#{server}/#{slug.downcase}"
+      "#{server}/#{slug}"
     end
 
     def transform_stats(stats)

--- a/app/frontend/tests/Tournament.svelte-test.ts
+++ b/app/frontend/tests/Tournament.svelte-test.ts
@@ -88,7 +88,7 @@ describe("Tournament", () => {
       it("displays tournament info and log in prompt", () => {
         // Tournament card
         expect(screen.getByLabelText("shortcode")).toHaveTextContent(
-          "ABC1 ( http://localhost:3000/ABC1 )",
+          "ABC1 (http://localhost:3000/ABC1)",
         );
         expect(screen.getByLabelText("date")).toHaveTextContent(
           "Tuesday, April 21, 2026",
@@ -107,7 +107,7 @@ describe("Tournament", () => {
           "17 active players (1 dropped)",
         );
         expect(screen.getByLabelText("QR code")).toHaveTextContent(
-          "Open Printable QR Code",
+          "Open QR Code",
         );
 
         // Registration card

--- a/app/frontend/tests/Tournament.svelte-test.ts
+++ b/app/frontend/tests/Tournament.svelte-test.ts
@@ -9,7 +9,11 @@ import {
 import Tournament from "../tournaments/Tournament.svelte";
 import { MockIdentityNames, MockTournament } from "./TournamentTestData";
 import { MockPlayerBob } from "./RoundsTestData";
-import { loadPlayer, loadTournament } from "../tournaments/TournamentSettings";
+import {
+  loadPlayer,
+  loadQRCode,
+  loadTournament,
+} from "../tournaments/TournamentSettings";
 import { loadIdentityNames } from "../identities/Identity";
 import userEvent from "@testing-library/user-event";
 import { Player, savePlayer } from "../players/PlayersData";
@@ -18,6 +22,7 @@ vi.mock("../tournaments/TournamentSettings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../pairings/PairingsData")>()),
   loadTournament: vi.fn(() => MockTournament),
   loadPlayer: vi.fn(() => MockPlayerBob),
+  loadQRCode: vi.fn(() => null),
 }));
 
 vi.mock("../identities/Identity", async (importOriginal) => ({
@@ -42,6 +47,9 @@ describe("Tournament", () => {
     await waitFor(() => {
       expect(loadPlayer).toHaveBeenCalledOnce();
     });
+    await waitFor(() => {
+      expect(loadQRCode).toHaveBeenCalledOnce();
+    });
   }
 
   beforeEach(() => {
@@ -57,6 +65,11 @@ describe("Tournament", () => {
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),
       })),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    window.URL.createObjectURL = vi.fn().mockImplementation((data: Blob) => {
+      return "";
     });
   });
 

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
-  import { loadPlayer, loadTournament, Tournament } from "./TournamentSettings";
+  import {
+    loadPlayer,
+    loadQRCode,
+    loadTournament,
+    Tournament,
+  } from "./TournamentSettings";
   import { Player } from "../players/PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import Registration from "../players/Registration.svelte";
+  import ModalDialog from "../widgets/ModalDialog.svelte";
 
   let {
     tournamentId,
@@ -20,9 +26,13 @@
   let player: Player | undefined = $state();
   let notices: string[] = $state([]);
 
+  let qrTest = $state("");
+
   onMount(async () => {
     tournament = await loadTournament(tournamentId);
     player = await loadPlayer(tournamentId, userId);
+
+    qrTest = URL.createObjectURL(await loadQRCode(tournamentId));
 
     if (player.id === 0) {
       player.name = userName ?? "";
@@ -135,10 +145,28 @@
           <li class="list-group-item">
             <div class="small text-secondary">QR Code:</div>
             <div class="row col-sm-6" aria-label="QR code">
-              <a href={`/tournaments/${tournamentId}/qr`} target="_blank">
+              <button
+                type="button"
+                class="btn btn-link p-0"
+                data-toggle="modal"
+                data-target="#qrCode"
+              >
                 <FontAwesomeIcon icon="qrcode" />
                 Open Printable QR Code
-              </a>
+              </button>
+
+              <ModalDialog id="qrCode" headerText="QR Code">
+                <div class="text-center">
+                  <h4 class="mb-3">
+                    {window.location.origin}/{tournament.slug}
+                  </h4>
+                  <img
+                    src={qrTest}
+                    class="w-100 h-100"
+                    alt="QR code of the tournament's URL"
+                  />
+                </div>
+              </ModalDialog>
             </div>
           </li>
         </div>

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -53,6 +53,21 @@
       }
     }
   });
+
+  function printQRCode() {
+    const qrCodeDiv = document.getElementById("qrCode");
+    if (!qrCodeDiv) {
+      return;
+    }
+
+    const printWindow = window.open();
+    if (!printWindow) {
+      return;
+    }
+    printWindow.document.children[0].append(qrCodeDiv.cloneNode(true));
+    printWindow.print();
+    printWindow.close();
+  }
 </script>
 
 <GlobalMessages />
@@ -149,22 +164,27 @@
                 type="button"
                 class="btn btn-link p-0"
                 data-toggle="modal"
-                data-target="#qrCode"
+                data-target="#qrCodeDialog"
               >
                 <FontAwesomeIcon icon="qrcode" />
-                Open Printable QR Code
+                Open QR Code
               </button>
 
-              <ModalDialog id="qrCode" headerText="QR Code">
+              <ModalDialog id="qrCodeDialog" headerText="QR Code">
                 <div class="text-center">
-                  <h4 class="mb-3">
-                    {window.location.origin}/{tournament.slug}
-                  </h4>
-                  <img
-                    src={qrTest}
-                    class="w-100 h-100"
-                    alt="QR code of the tournament's URL"
-                  />
+                  <button type="button" class="btn btn-primary mb-3" onclick={printQRCode}>
+                    <FontAwesomeIcon icon="print" /> Print
+                  </button>
+                  <div id="qrCode">
+                    <h4 class="mb-3">
+                      {window.location.origin}/{tournament.slug}
+                    </h4>
+                    <img
+                      src={qrTest}
+                      class="w-100 h-100"
+                      alt="QR code of the tournament's URL"
+                    />
+                  </div>
                 </div>
               </ModalDialog>
             </div>

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -26,13 +26,13 @@
   let player: Player | undefined = $state();
   let notices: string[] = $state([]);
 
-  let qrTest = $state("");
+  let qrCodeImageData = $state("");
 
   onMount(async () => {
     tournament = await loadTournament(tournamentId);
     player = await loadPlayer(tournamentId, userId);
 
-    qrTest = URL.createObjectURL(await loadQRCode(tournamentId));
+    qrCodeImageData = URL.createObjectURL(await loadQRCode(tournamentId));
 
     if (player.id === 0) {
       player.name = userName ?? "";
@@ -88,11 +88,9 @@
             <li class="list-group-item" aria-label="shortcode">
               <div class="small text-secondary">Shortcode:</div>
               {tournament.slug}
-              (
-              <a href={`/${tournament.slug}`}>
+              (<a href={`/${tournament.slug}`}>
                 {window.location.origin}/{tournament.slug}
-              </a>
-              )
+              </a>)
             </li>
           {/if}
 
@@ -172,7 +170,11 @@
 
               <ModalDialog id="qrCodeDialog" headerText="QR Code">
                 <div class="text-center">
-                  <button type="button" class="btn btn-primary mb-3" onclick={printQRCode}>
+                  <button
+                    type="button"
+                    class="btn btn-primary mb-3"
+                    onclick={printQRCode}
+                  >
                     <FontAwesomeIcon icon="print" /> Print
                   </button>
                   <div id="qrCode">
@@ -180,7 +182,7 @@
                       {window.location.origin}/{tournament.slug}
                     </h4>
                     <img
-                      src={qrTest}
+                      src={qrCodeImageData}
                       class="w-100 h-100"
                       alt="QR code of the tournament's URL"
                     />

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -64,7 +64,7 @@
     if (!printWindow) {
       return;
     }
-    printWindow.document.children[0].append(qrCodeDiv.cloneNode(true));
+    printWindow.document.body.append(qrCodeDiv.cloneNode(true));
     printWindow.print();
     printWindow.close();
   }

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -9,6 +9,7 @@ declare const Routes: {
   api_v1_public_tournament_path: (tournamentId: number) => string;
   tournaments_path: () => string;
   registration_notice_beta_tournament_path: (tournamentId: number) => string;
+  qr_beta_tournament_path: (tournamentId: number) => string;
 };
 
 export class Tournament {
@@ -283,4 +284,12 @@ export class ValidationError extends Error {
     super("Validation failed");
     this.name = "ValidationError";
   }
+}
+
+export async function loadQRCode(tournamentId: number) {
+  const response = await fetch(Routes.qr_beta_tournament_path(tournamentId), {
+    method: "GET",
+  });
+
+  return await response.blob();
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
         patch :reinstate, on: :member
         get :decks, on: :collection
       end
+      get :qr, on: :member
       resources :stages, only: %i[create destroy]
       patch :open_registration, on: :member
       patch :close_registration, on: :member


### PR DESCRIPTION
The tournament QR code page has been converted into a dialog on the Tournament tab. This is very straightforward - request the QR code SVG from the server, render it in a `ModalDialog`, and provide a button that allows the user to print a full-sized version of it.