### PR TITLE
Fix single elim display

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -54,6 +54,8 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
           pairing[:winner_game] = bracket_game ? bracket_game[:winner_game] : nil
           pairing[:loser_game] = bracket_game ? bracket_game[:loser_game] : nil
           pairing[:bracket_type] = bracket_game ? bracket_game[:bracket_type] : nil
+          pairing[:player1_seed] = bracket_game ? bracket_game[:player1_seed] : nil
+          pairing[:player2_seed] = bracket_game ? bracket_game[:player2_seed] : nil
         end
       end
 
@@ -155,7 +157,8 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
 
   def pairings_data_stages
     players = pairings_data_players
-    @tournament.stages.includes(:rounds).map do |stage|
+    @tournament.stages.includes(:rounds, :registrations).map do |stage|
+      stage_players = pairings_data_players_with_seeds(players, stage)
       {
         id: stage.id,
         name: stage.format.titleize,
@@ -163,9 +166,17 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         is_single_sided: stage.single_sided?,
         is_elimination: stage.elimination?,
         view_decks: stage.decks_visible_to?(current_user),
-        rounds: pairings_data_rounds(stage, players),
+        rounds: pairings_data_rounds(stage, stage_players),
         player_count: stage.players.count
       }
+    end
+  end
+
+  def pairings_data_players_with_seeds(players, stage)
+    seeds = stage.registrations.to_h { |r| [r.player_id, r.seed] }
+    players.transform_values do |p|
+      seed = seeds[p['id']]
+      seed ? p.merge('seed' => seed) : p
     end
   end
 
@@ -306,6 +317,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
       id: (player['id'] if player),
       name: (player['name'] if player),
       name_with_pronouns: name_with_pronouns(player),
+      seed: (player['seed'] if player),
       side:,
       user_id: (player['user_id'] if player),
       side_label: side_label(side),
@@ -409,7 +421,9 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         round: game[:round],
         winner_game: game[:winner_game],
         loser_game: game[:loser_game],
-        bracket_type: game[:bracket_type].to_s
+        bracket_type: game[:bracket_type].to_s,
+        player1_seed: game[:player1_seed],
+        player2_seed: game[:player2_seed]
       }
     end
   end

--- a/app/frontend/bracket/BracketData.ts
+++ b/app/frontend/bracket/BracketData.ts
@@ -44,11 +44,14 @@ export interface BracketPairing {
   player1?: Player;
   player2?: Player;
   score_label?: string;
+  player1_seed?: number;
+  player2_seed?: number;
 }
 
 export interface Player {
   id: number;
   name_with_pronouns: string;
+  seed?: number;
   side: string | null;
   user_id: string | null;
   side_label: string | null;

--- a/app/frontend/bracket/BracketDisplay.svelte
+++ b/app/frontend/bracket/BracketDisplay.svelte
@@ -37,18 +37,37 @@
   const predecessorMap: PredecessorMap = $derived.by(() => {
     const map: PredecessorMap = {};
 
-    for (const pairing of allPairings) {
-      if (pairing.winner_game) {
-        map[pairing.winner_game] = [
-          ...(map[pairing.winner_game] ?? []),
-          { method: "winner", game: pairing.table_number },
-        ];
+    if (isDoubleElim) {
+      for (const pairing of allPairings) {
+        if (pairing.winner_game) {
+          map[pairing.winner_game] = [
+            ...(map[pairing.winner_game] ?? []),
+            { method: "winner", game: pairing.table_number },
+          ];
+        }
+        if (pairing.loser_game) {
+          map[pairing.loser_game] = [
+            ...(map[pairing.loser_game] ?? []),
+            { method: "loser", game: pairing.table_number },
+          ];
+        }
       }
-      if (pairing.loser_game) {
-        map[pairing.loser_game] = [
-          ...(map[pairing.loser_game] ?? []),
-          { method: "loser", game: pairing.table_number },
-        ];
+    } else {
+      for (let c = 1; c < upperCols.length; c++) {
+        for (const game of upperCols[c]) {
+          for (const player of [game.player1, game.player2]) {
+            if (!player) continue;
+            const prevGame = upperCols[c - 1].find(
+              (g) => g.player1?.id === player.id || g.player2?.id === player.id,
+            );
+            if (prevGame) {
+              map[game.table_number] = [
+                ...(map[game.table_number] ?? []),
+                { method: "winner", game: prevGame.table_number },
+              ];
+            }
+          }
+        }
       }
     }
 
@@ -136,7 +155,11 @@
   const svgHeightLower = $derived(
     padding * 2 + Math.max(1, numLowerRows) * (matchHeight + matchGap),
   );
-  const svgHeightTotal = $derived(svgHeightUpper + bracketGap + svgHeightLower);
+  const svgHeightTotal = $derived(
+    lowerRounds.length > 0
+      ? svgHeightUpper + bracketGap + svgHeightLower
+      : svgHeightUpper,
+  );
 
   // For connectors: map winner_game within same bracket
   const connectorPath = $derived(
@@ -246,28 +269,30 @@
   <svg width={svgWidth} height={svgHeightTotal} role="img" aria-label="Bracket">
     {#if upperRounds.length > 0}
       <g>
-        <g>
-          <!-- Connectors -->
-          {#each upperCols as col, cIdx (cIdx)}
-            {#each col as m, rIdx (m.table_number)}
-              {#if m.winner_game != null}
-                {#if upperIndex.has(String(m.winner_game))}
-                  <path
-                    d={connectorPathTo(
-                      upperIndex,
-                      cIdx,
-                      rIdx,
-                      m.winner_game,
-                      upperY,
-                    )}
-                    stroke="#999"
-                    fill="none"
-                  />
+        {#if isDoubleElim}
+          <g>
+            <!-- Connectors (double elim only) -->
+            {#each upperCols as col, cIdx (cIdx)}
+              {#each col as m, rIdx (m.table_number)}
+                {#if m.winner_game != null}
+                  {#if upperIndex.has(String(m.winner_game))}
+                    <path
+                      d={connectorPathTo(
+                        upperIndex,
+                        cIdx,
+                        rIdx,
+                        m.winner_game,
+                        upperY,
+                      )}
+                      stroke="#999"
+                      fill="none"
+                    />
+                  {/if}
                 {/if}
-              {/if}
+              {/each}
             {/each}
-          {/each}
-        </g>
+          </g>
+        {/if}
 
         <!-- Matches -->
         {#each upperCols as col, cIdx (cIdx)}
@@ -276,6 +301,7 @@
               {match}
               allMatches={allPairings}
               {predecessorMap}
+              isSingleElim={!isDoubleElim}
               x={columnX(cIdx)}
               y={upperY[cIdx]?.[rIdx] ?? baseMatchY(rIdx)}
               width={columnWidth}
@@ -318,6 +344,7 @@
               {match}
               allMatches={allPairings}
               {predecessorMap}
+              isSingleElim={false}
               x={columnX(cIdx + lowerColOffset)}
               y={lowerY[cIdx]?.[rIdx] ?? baseMatchY(rIdx)}
               width={columnWidth}

--- a/app/frontend/bracket/BracketMatchNode.svelte
+++ b/app/frontend/bracket/BracketMatchNode.svelte
@@ -12,6 +12,7 @@
   export let match: BracketPairing;
   export let allMatches: BracketPairing[];
   export let predecessorMap: PredecessorMap;
+  export let isSingleElim: boolean = false;
   export let x: number;
   export let y: number;
   export let width: number;
@@ -108,10 +109,17 @@
 
 <g transform={`translate(${x}, ${y})`}>
   <rect {width} {height} rx="6" ry="6" fill="#fff" stroke="#ccc" />
-  <text x="8" y={height / 2} class="game-label" dominant-baseline="middle"
-    >{match.table_number}</text
+  {#if !isSingleElim}
+    <text x="8" y={height / 2} class="game-label" dominant-baseline="middle"
+      >{match.table_number}</text
+    >
+  {/if}
+  <foreignObject
+    x={isSingleElim ? 8 : 28}
+    y="2"
+    width={isSingleElim ? width - 20 : width - 40}
+    height={height - 4}
   >
-  <foreignObject x="28" y="2" width={width - 40} height={height - 4}>
     <div xmlns="http://www.w3.org/1999/xhtml" class="small content">
       <div class="player-line d-flex" class:mb-1={$showIdentities}>
         <div
@@ -126,6 +134,9 @@
           {#if topPlayer}
             {@const identity = getIdentity(topPlayer)}
             <div class="player-info">
+              {#if isSingleElim && topPlayer.seed != null}
+                <span class="seed-label">{topPlayer.seed}</span>
+              {/if}
               {#if identity}
                 <IdentityComponent
                   {identity}
@@ -148,6 +159,10 @@
                 </div>
               {/if}
             {/if}
+          {:else if match.player1_seed != null}
+            <span class="truncate placeholder-text"
+              >New {match.player1_seed} seed</span
+            >
           {:else if topPlayerName ?? topFallback}
             <span
               class="truncate"
@@ -173,6 +188,9 @@
           {#if bottomPlayer}
             {@const identity = getIdentity(bottomPlayer)}
             <div class="player-info">
+              {#if isSingleElim && bottomPlayer.seed != null}
+                <span class="seed-label">{bottomPlayer.seed}</span>
+              {/if}
               {#if identity}
                 <IdentityComponent
                   {identity}
@@ -195,6 +213,10 @@
                 </div>
               {/if}
             {/if}
+          {:else if match.player2_seed != null}
+            <span class="truncate placeholder-text"
+              >New {match.player2_seed} seed</span
+            >
           {:else if bottomPlayerName ?? bottomFallback}
             <span
               class="truncate"
@@ -249,6 +271,14 @@
     font-size: 0.75rem;
     fill: #6c757d;
     font-weight: 500;
+  }
+  .seed-label {
+    font-size: 0.75rem;
+    color: #6c757d;
+    font-weight: 500;
+    min-width: 1.2em;
+    text-align: right;
+    flex-shrink: 0;
   }
   .ids {
     font-size: 0.7rem;

--- a/app/services/bracket/engine.rb
+++ b/app/services/bracket/engine.rb
@@ -6,6 +6,14 @@ module Bracket
       base.extend ClassMethods
     end
 
+    SeedRef = Struct.new(:seed_position) do
+      def call(context) = context.seed(seed_position)
+    end
+
+    SeedOf = Struct.new(:players, :seed_position) do
+      def call(context) = context.seed_of(players, seed_position)
+    end
+
     module ClassMethods # rubocop:disable Style/Documentation
       def game(number, p1, p2, options = {}) # rubocop:disable Naming/MethodParameterName
         class_eval do
@@ -17,12 +25,22 @@ module Bracket
             round: options[:round],
             winner_game: options[:winner_game],
             loser_game: options[:loser_game],
-            bracket_type: options[:bracket_type]
+            bracket_type: options[:bracket_type],
+            player1_seed: p1.respond_to?(:seed_position) ? p1.seed_position : nil,
+            player2_seed: p2.respond_to?(:seed_position) ? p2.seed_position : nil
           }
         end
       end
 
-      %w[seed winner loser seed_of winner_if_also_winner loser_if_also_winner].each do |method|
+      def seed(pos)
+        SeedRef.new(pos)
+      end
+
+      def seed_of(players, pos)
+        SeedOf.new(players, pos)
+      end
+
+      %w[winner loser winner_if_also_winner loser_if_also_winner].each do |method|
         define_method method do |*args|
           args.unshift(method)
           ->(context) { context.send(*args) }

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -201,8 +201,8 @@ RSpec.describe RoundsController do
                            'completed' => false,
                            'pairings' => [
                              { 'intentional_draw' => false,
-                               'player1' => player_with_no_ids('Bob', 'he/him'),
-                               'player2' => player_with_no_ids('Charlie', 'she/her'),
+                               'player1' => player_with_no_ids('Bob', 'he/him', seed: 2),
+                               'player2' => player_with_no_ids('Charlie', 'she/her', seed: 3),
                                'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
                                'reported' => false,
@@ -268,8 +268,8 @@ RSpec.describe RoundsController do
                            'completed' => false,
                            'pairings' => [
                              { 'intentional_draw' => false,
-                               'player1' => player_with_no_ids('Bob', 'he/him'),
-                               'player2' => player_with_no_ids('Charlie', 'she/her'),
+                               'player1' => player_with_no_ids('Bob', 'he/him', seed: 2),
+                               'player2' => player_with_no_ids('Charlie', 'she/her', seed: 3),
                                'policy' => { 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
                                'reported' => false,
@@ -277,7 +277,8 @@ RSpec.describe RoundsController do
                                'score2' => nil,
                                'score_label' => ' - ', 'two_for_one' => false,
                                'table_label' => 'Game 1', 'table_number' => 1, 'self_reports' => nil,
-                               'round' => 1, 'bracket_type' => 'upper', 'winner_game' => 2, 'loser_game' => nil }
+                               'round' => 1, 'bracket_type' => 'upper', 'winner_game' => 2, 'loser_game' => nil,
+                               'player1_seed' => 2, 'player2_seed' => 3 }
                            ],
                            'pairings_reported' => 0,
                            'length_minutes' => 40,
@@ -291,7 +292,9 @@ RSpec.describe RoundsController do
                                'round' => 2,
                                'bracket_type' => 'upper',
                                'winner_game' => nil,
-                               'loser_game' => nil
+                               'loser_game' => nil,
+                               'player1_seed' => 1,
+                               'player2_seed' => nil
                              }
                            ]
                          }
@@ -476,13 +479,14 @@ RSpec.describe RoundsController do
     }
   end
 
-  def player_with_no_ids(name, pronouns, side: nil, side_label: nil)
+  def player_with_no_ids(name, pronouns, side: nil, side_label: nil, seed: nil)
     {
       'name' => name,
       'name_with_pronouns' => "#{name} (#{pronouns})",
       'user_id' => nil,
       'corp_id' => { 'faction' => nil, 'name' => nil },
       'runner_id' => { 'faction' => nil, 'name' => nil },
+      'seed' => seed,
       'side' => side,
       'side_label' => side_label
     }
@@ -495,6 +499,7 @@ RSpec.describe RoundsController do
       'user_id' => nil,
       'corp_id' => nil,
       'runner_id' => nil,
+      'seed' => nil,
       'side' => nil,
       'side_label' => nil
     }


### PR DESCRIPTION
API changes:

- Track player seed per game via `SeedRef`/`SeedOf` structs and drill down to `player1_seed` and `player2_seed` fields

UI changes for single elim:

- Build predecessor map using column traversal rather than `winner_game`
- Hide connector paths and lower bracket SVG gap in single elim
- Show seeds next to player names and "New N seed" placeholders for future rounds


Top 2:
<img width="388" height="208" alt="Screenshot 2026-05-04 at 4 31 58 PM" src="https://github.com/user-attachments/assets/de36fd30-9035-42fe-b112-ddfc2c996f53" />


Top 3:
<img width="628" height="221" alt="Screenshot 2026-05-04 at 4 31 43 PM" src="https://github.com/user-attachments/assets/db01a23b-245a-483a-820e-31677e85e4e7" />


Top 4:
<img width="625" height="310" alt="Screenshot 2026-05-04 at 4 30 53 PM" src="https://github.com/user-attachments/assets/14845b24-92e2-4bf6-8e0a-644ee5855fca" />

Top 8:
<img width="1134" height="498" alt="Screenshot 2026-04-30 at 12 28 20 PM" src="https://github.com/user-attachments/assets/e1a55dd1-8280-480e-b1ff-6c67a5e38ed1" />

Top 16:
<img width="1133" height="869" alt="Screenshot 2026-05-04 at 4 29 52 PM" src="https://github.com/user-attachments/assets/baac9454-616c-4306-8092-0955f758f320" />
