### PR TITLE
Resolving Svelte binding warnings

### DIFF
--- a/app/frontend/pairings/AdminReportOptions.svelte
+++ b/app/frontend/pairings/AdminReportOptions.svelte
@@ -28,15 +28,18 @@
       : pairing.player2,
   );
   let showScorePresets = $derived(!pairing.reported);
-  let customReport: ScoreReport = $derived({
-    score1: pairing.score1,
-    score2: pairing.score2,
-    intentional_draw: pairing.intentional_draw,
-    two_for_one: pairing.two_for_one,
-    score1_corp: 0,
-    score2_runner: 0,
-    score1_runner: 0,
-    score2_corp: 0,
+  let customReport: ScoreReport = $derived.by(() => {
+    let report = $state({
+      score1: pairing.score1,
+      score2: pairing.score2,
+      intentional_draw: pairing.intentional_draw,
+      two_for_one: pairing.two_for_one,
+      score1_corp: 0,
+      score2_runner: 0,
+      score1_runner: 0,
+      score2_corp: 0,
+    });
+    return report;
   });
 
   function toggleShowScorePresets() {

--- a/app/frontend/players/PlayerForm.svelte
+++ b/app/frontend/players/PlayerForm.svelte
@@ -31,7 +31,8 @@
     deletedCallback?: (player: Player) => void;
   } = $props();
 
-  let playerEdit = $derived($state.snapshot(player));
+  // svelte-ignore state_referenced_locally
+  let playerEdit = $state($state.snapshot(player));
 
   async function togglePlayerLock() {
     const success = await togglePlayerLockRequest(tournament.id, playerEdit);

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -21,16 +21,18 @@
   } = $props();
 
   let identityNames: IdentityNames | undefined = $state();
-  let playerAgreed = $state(false);
   // svelte-ignore state_referenced_locally
-  let readOnly = $state(player.id !== 0);
+  let playerEdit = $state($state.snapshot(player));
+  let playerAgreed = $state(false);
+  let readOnly = $derived(playerEdit.id !== 0);
 
   onMount(async () => {
     identityNames = await loadIdentityNames();
+    playerEdit.name = player.name;
   });
 
   async function savePlayer() {
-    player = await savePlayerRequest(tournament.id, player);
+    playerEdit = await savePlayerRequest(tournament.id, playerEdit);
     readOnly = true;
   }
 </script>
@@ -62,14 +64,14 @@
       <li class="list-group-item">
         <div class="small text-secondary">Name:</div>
         <div aria-label="name">
-          {player.name_with_pronouns}
+          {playerEdit.name_with_pronouns}
         </div>
       </li>
       <li class="list-group-item">
         <div class="small text-secondary">Corp ID:</div>
         <div aria-label="corp ID">
           <Identity
-            identity={player.corp_id}
+            identity={playerEdit.corp_id}
             name_if_missing="Unspecified"
             icon_if_missing="interrupt"
           />
@@ -79,7 +81,7 @@
         <div class="small text-secondary">Runner ID:</div>
         <div aria-label="runner ID">
           <Identity
-            identity={player.runner_id}
+            identity={playerEdit.runner_id}
             name_if_missing="Unspecified"
             icon_if_missing="interrupt"
           />
@@ -87,7 +89,7 @@
       </li>
       <li class="list-group-item">
         <div class="small text-secondary">First Round Bye:</div>
-        {#if player.first_round_bye}
+        {#if playerEdit.first_round_bye}
           <div class="badge badge-success" aria-label="first round bye">
             YES
           </div>
@@ -99,7 +101,7 @@
       </li>
       <li class="list-group-item">
         <div class="small text-secondary">Stream my games:</div>
-        {#if player.include_in_stream}
+        {#if playerEdit.include_in_stream}
           <div class="badge badge-success" aria-label="stream my games">
             YES
           </div>
@@ -115,14 +117,14 @@
   <div class="card alert alert-secondary">
     <div class="card-header d-flex justify-content-between">
       <h5 class="mb-0">
-        {#if player.id === 0}
+        {#if playerEdit.id === 0}
           Register for this Event
         {:else}
           My Registration Information
         {/if}
       </h5>
 
-      {#if player.id !== 0}
+      {#if playerEdit.id !== 0}
         <button
           type="button"
           class="btn btn-link text-info p-0"
@@ -144,7 +146,7 @@
           type="text"
           placeholder="Enter your name"
           class="form-control"
-          bind:value={player.name}
+          bind:value={playerEdit.name}
         />
       </div>
 
@@ -155,7 +157,7 @@
           type="text"
           placeholder="Example: they/them"
           class="form-control"
-          bind:value={player.pronouns}
+          bind:value={playerEdit.pronouns}
         />
       </div>
 
@@ -166,7 +168,7 @@
             id="corp-identity"
             placeholder="Search for corp ID"
             identityNames={identityNames ? identityNames.corp : []}
-            bind:value={player.corp_id.name}
+            bind:value={playerEdit.corp_id.name}
           />
         </div>
 
@@ -176,7 +178,7 @@
             id="runner-identity"
             placeholder="Search for runner ID"
             identityNames={identityNames ? identityNames.runner : []}
-            bind:value={player.runner_id.name}
+            bind:value={playerEdit.runner_id.name}
           />
         </div>
       {/if}
@@ -191,7 +193,7 @@
           <input
             id="include_in_stream"
             type="checkbox"
-            bind:checked={player.include_in_stream}
+            bind:checked={playerEdit.include_in_stream}
           />
           <label for="include_in_stream">
             Include my games in video coverage
@@ -204,7 +206,7 @@
           <input
             id="first_round_bye"
             type="checkbox"
-            bind:checked={player.first_round_bye}
+            bind:checked={playerEdit.first_round_bye}
           />
           <label for="first_round_bye">First Round Bye</label>
         </div>
@@ -217,13 +219,13 @@
               type="number"
               placeholder="Set seed"
               class="form-control"
-              bind:value={player.manual_seed}
+              bind:value={playerEdit.manual_seed}
             />
           </div>
         {/if}
       {/if}
 
-      {#if player.id === 0}
+      {#if playerEdit.id === 0}
         <hr />
 
         <div class="form-group">
@@ -247,11 +249,11 @@
       <button
         type="button"
         class="btn btn-primary"
-        disabled={player.id === 0 && !playerAgreed}
+        disabled={playerEdit.id === 0 && !playerAgreed}
         onclick={savePlayer}
       >
         <FontAwesomeIcon icon="user-plus" />
-        {#if player.id !== 0}
+        {#if playerEdit.id !== 0}
           Submit
         {:else if tournament.nrdb_deck_registration}
           Deck Registration

--- a/app/frontend/tournaments/DemoTournamentCreation.svelte
+++ b/app/frontend/tournaments/DemoTournamentCreation.svelte
@@ -11,8 +11,6 @@
 
   let tournament: DemoTournamentSettings;
   let csrfToken = "";
-
-  let isSubmitting = false;
   let errors: Errors = {};
 
   onMount(async () => {
@@ -22,7 +20,6 @@
   });
 
   async function submitNewTournament() {
-    isSubmitting = true;
     errors = {};
 
     try {
@@ -34,8 +31,6 @@
       } else {
         errors = { base: ["An unexpected error occurred. Please try again."] };
       }
-    } finally {
-      isSubmitting = false;
     }
   }
 </script>
@@ -57,7 +52,6 @@
           onSubmit={submitNewTournament}
           submitLabel="Create"
           submitIcon="plus"
-          {isSubmitting}
           {errors}
         />
       </form>

--- a/app/frontend/tournaments/DemoTournamentCreation.svelte-test.ts
+++ b/app/frontend/tournaments/DemoTournamentCreation.svelte-test.ts
@@ -200,31 +200,4 @@ describe("DemoTournamentCreation", () => {
       ).toBeInTheDocument();
     });
   });
-
-  it("disables submit button while submitting", async () => {
-    const { createDemoTournament } = await import("./DemoTournamentSettings");
-    // Make createDemoTournament hang to test loading state
-    vi.mocked(createDemoTournament).mockImplementation(
-      () =>
-        new Promise(() => {
-          // This promise intentionally never resolves to test loading state
-        }),
-    );
-
-    render(DemoTournamentCreation);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
-    });
-
-    const submitButton = screen.getByRole("button", {
-      name: /create/i,
-    });
-    await fireEvent.click(submitButton);
-
-    // Button should be disabled while submitting
-    await waitFor(() => {
-      expect(submitButton).toBeDisabled();
-    });
-  });
 });

--- a/app/frontend/tournaments/TournamentCreation.svelte
+++ b/app/frontend/tournaments/TournamentCreation.svelte
@@ -16,8 +16,6 @@
   let options: TournamentOptions = emptyTournamentOptions();
   let featureFlags: FeatureFlags = {};
   let csrfToken = "";
-
-  let isSubmitting = false;
   let errors: Errors = {};
 
   onMount(async () => {
@@ -29,8 +27,7 @@
     csrfToken = data.csrf_token;
   });
 
-  async function submitNewTournament() {
-    isSubmitting = true;
+  async function submitNewTournament(tournament: Tournament) {
     errors = {};
 
     try {
@@ -42,8 +39,6 @@
       } else {
         errors = { base: ["An unexpected error occurred. Please try again."] };
       }
-    } finally {
-      isSubmitting = false;
     }
   }
 </script>
@@ -55,18 +50,15 @@
     {#if errors.base}
       <div class="alert alert-danger">{errors.base}</div>
     {:else if tournament}
-      <form on:submit|preventDefault={submitNewTournament}>
-        <TournamentSettingsForm
-          {tournament}
-          {options}
-          {featureFlags}
-          onSubmit={submitNewTournament}
-          submitLabel="Create"
-          submitIcon="plus"
-          {isSubmitting}
-          {errors}
-        />
-      </form>
+      <TournamentSettingsForm
+        {tournament}
+        {options}
+        {featureFlags}
+        onSubmitCallback={submitNewTournament}
+        submitLabel="Create"
+        submitIcon="plus"
+        {errors}
+      />
     {:else}
       <div class="d-flex align-items-center m-2" data-testid="loading-spinner">
         <div class="spinner-border m-auto"></div>

--- a/app/frontend/tournaments/TournamentSettingsForm.svelte
+++ b/app/frontend/tournaments/TournamentSettingsForm.svelte
@@ -7,6 +7,7 @@
     type TournamentOptions,
   } from "./TournamentSettings";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+  import ProgressButton from "../widgets/ProgressButton.svelte";
 
   let {
     tournament,
@@ -14,21 +15,20 @@
     featureFlags = {},
     submitLabel = "Save",
     submitIcon = "floppy-o",
-    isSubmitting = false,
     errors = {},
-    onSubmit = () => {
-      isSubmitting = true;
-    },
+    onSubmitCallback,
   }: {
     tournament: Tournament;
     options?: TournamentOptions;
     featureFlags?: FeatureFlags;
     submitLabel?: string;
     submitIcon?: string;
-    isSubmitting?: boolean;
     errors?: Errors;
-    onSubmit?: () => void;
+    onSubmitCallback?: (tournament: Tournament) => void;
   } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let tournamentEdit = $state($state.snapshot(tournament));
 </script>
 
 <div class="form-group">
@@ -37,7 +37,7 @@
     type="text"
     id="name"
     class="form-control"
-    bind:value={tournament.name}
+    bind:value={tournamentEdit.name}
   />
   {#if errors.name}
     <div class="invalid-feedback d-block">{errors.name}</div>
@@ -52,7 +52,7 @@
         type="date"
         id="date"
         class="form-control"
-        bind:value={tournament.date}
+        bind:value={tournamentEdit.date}
       />
       {#if errors.date}
         <div class="invalid-feedback d-block">{errors.date}</div>
@@ -65,7 +65,7 @@
       <select
         id="time_zone"
         class="form-control"
-        bind:value={tournament.time_zone}
+        bind:value={tournamentEdit.time_zone}
       >
         {#each options.time_zones as time_zone (time_zone.id)}
           <option value={time_zone.id}>{time_zone.name}</option>
@@ -86,7 +86,7 @@
         type="time"
         id="registration_starts"
         class="form-control"
-        bind:value={tournament.registration_starts}
+        bind:value={tournamentEdit.registration_starts}
       />
       {#if errors.registration_starts}
         <div class="invalid-feedback d-block">{errors.registration_starts}</div>
@@ -100,7 +100,7 @@
         type="time"
         id="tournament_starts"
         class="form-control"
-        bind:value={tournament.tournament_starts}
+        bind:value={tournamentEdit.tournament_starts}
       />
       {#if errors.tournament_starts}
         <div class="invalid-feedback d-block">{errors.tournament_starts}</div>
@@ -114,7 +114,7 @@
   <select
     id="swiss_format"
     class="form-control"
-    bind:value={tournament.swiss_format}
+    bind:value={tournamentEdit.swiss_format}
   >
     <option value="double_sided">Double-sided</option>
     <option value="single_sided">Single-sided</option>
@@ -131,7 +131,7 @@
       <select
         id="tournament_type_id"
         class="form-control"
-        bind:value={tournament.tournament_type_id}
+        bind:value={tournamentEdit.tournament_type_id}
       >
         <option value=""></option>
         {#each options.tournament_types as tournament_type (tournament_type.id)}
@@ -149,7 +149,7 @@
       <select
         id="card_set_id"
         class="form-control"
-        bind:value={tournament.card_set_id}
+        bind:value={tournamentEdit.card_set_id}
       >
         <option value=""></option>
         {#each options.card_sets as card_set (card_set.id)}
@@ -170,7 +170,7 @@
       <select
         id="format_id"
         class="form-control"
-        bind:value={tournament.format_id}
+        bind:value={tournamentEdit.format_id}
       >
         <option value=""></option>
         {#each options.formats as format (format.id)}
@@ -188,7 +188,7 @@
       <select
         id="deckbuilding_restriction_id"
         class="form-control"
-        bind:value={tournament.deckbuilding_restriction_id}
+        bind:value={tournamentEdit.deckbuilding_restriction_id}
       >
         <option value=""></option>
         {#each options.deckbuilding_restrictions as restriction (restriction.id)}
@@ -209,7 +209,7 @@
     type="checkbox"
     id="decklist_required"
     class="form-check-input"
-    bind:checked={tournament.decklist_required}
+    bind:checked={tournamentEdit.decklist_required}
   />
   <label for="decklist_required" class="form-check-label">
     Decklist required for event
@@ -222,7 +222,7 @@
     type="text"
     id="organizer_contact"
     class="form-control"
-    bind:value={tournament.organizer_contact}
+    bind:value={tournamentEdit.organizer_contact}
   />
   {#if errors.organizer_contact}
     <div class="invalid-feedback d-block">{errors.organizer_contact}</div>
@@ -235,7 +235,7 @@
     type="url"
     id="event_link"
     class="form-control"
-    bind:value={tournament.event_link}
+    bind:value={tournamentEdit.event_link}
   />
   {#if errors.event_link}
     <div class="invalid-feedback d-block">{errors.event_link}</div>
@@ -247,7 +247,7 @@
   <textarea
     id="description"
     class="form-control"
-    bind:value={tournament.description}
+    bind:value={tournamentEdit.description}
   ></textarea>
   {#if errors.description}
     <div class="invalid-feedback d-block">{errors.description}</div>
@@ -259,7 +259,7 @@
   <select
     id="official_prize_kit_id"
     class="form-control"
-    bind:value={tournament.official_prize_kit_id}
+    bind:value={tournamentEdit.official_prize_kit_id}
   >
     <option value=""></option>
     {#each options.official_prize_kits as prize_kit (prize_kit.id)}
@@ -278,7 +278,7 @@
   <textarea
     id="additional_prizes_description"
     class="form-control"
-    bind:value={tournament.additional_prizes_description}
+    bind:value={tournamentEdit.additional_prizes_description}
   ></textarea>
   {#if errors.additional_prizes_description}
     <div class="invalid-feedback d-block">
@@ -293,7 +293,7 @@
     type="url"
     id="stream_url"
     class="form-control"
-    bind:value={tournament.stream_url}
+    bind:value={tournamentEdit.stream_url}
   />
   {#if errors.stream_url}
     <div class="invalid-feedback d-block">{errors.stream_url}</div>
@@ -305,7 +305,7 @@
     type="checkbox"
     id="self_registration"
     class="form-check-input"
-    bind:checked={tournament.self_registration}
+    bind:checked={tournamentEdit.self_registration}
   />
   <label for="self_registration" class="form-check-label">
     Self-Registration: Allow players to use a link to register themselves
@@ -317,7 +317,7 @@
     type="checkbox"
     id="nrdb_deck_registration"
     class="form-check-input"
-    bind:checked={tournament.nrdb_deck_registration}
+    bind:checked={tournamentEdit.nrdb_deck_registration}
   />
   <label for="nrdb_deck_registration" class="form-check-label">
     Deck registration: Upload decks from NetrunnerDB
@@ -329,7 +329,7 @@
     type="checkbox"
     id="private"
     class="form-check-input"
-    bind:checked={tournament.private}
+    bind:checked={tournamentEdit.private}
   />
   <label for="private" class="form-check-label">
     Private: Only I will be able to view this tournament
@@ -341,7 +341,7 @@
     type="checkbox"
     id="manual_seed"
     class="form-check-input"
-    bind:checked={tournament.manual_seed}
+    bind:checked={tournamentEdit.manual_seed}
   />
   <label for="manual_seed" class="form-check-label">
     Use manual seeding for tiebreakers: Players can be assigned a "seed" value
@@ -355,7 +355,7 @@
     type="checkbox"
     id="allow_streaming_opt_out"
     class="form-check-input"
-    bind:checked={tournament.allow_streaming_opt_out}
+    bind:checked={tournamentEdit.allow_streaming_opt_out}
   />
   <label for="allow_streaming_opt_out" class="form-check-label">
     Streaming opt out: Allow players to choose whether their games should be
@@ -370,7 +370,7 @@
       type="checkbox"
       id="allow_self_reporting"
       class="form-check-input"
-      bind:checked={tournament.allow_self_reporting}
+      bind:checked={tournamentEdit.allow_self_reporting}
     />
     <label for="allow_self_reporting" class="form-check-label">
       Allow logged-in players to report their own match results
@@ -379,22 +379,15 @@
 {/if}
 
 <div class="form-group">
-  <button
-    type="submit"
-    class="btn btn-primary"
-    onclick={onSubmit}
-    disabled={isSubmitting}
+  <ProgressButton
+    css="btn btn-primary"
+    inProgressText="Saving"
+    completeText="Saved"
+    onclick={() => {
+      onSubmitCallback?.(tournamentEdit);
+    }}
   >
     <FontAwesomeIcon icon={submitIcon} />
-    {#if isSubmitting}
-      <span
-        class="spinner-border spinner-border-sm"
-        role="status"
-        aria-hidden="true"
-      ></span>
-      Saving...
-    {:else}
-      {submitLabel}
-    {/if}
-  </button>
+    {submitLabel}
+  </ProgressButton>
 </div>

--- a/app/frontend/tournaments/TournamentSettingsForm.svelte-test.ts
+++ b/app/frontend/tournaments/TournamentSettingsForm.svelte-test.ts
@@ -114,7 +114,7 @@ describe("TournamentSettingsForm", () => {
         tournament: tournament,
         options: options,
         featureFlags: featureFlags,
-        onSubmit: mockOnSubmit,
+        onSubmitCallback: mockOnSubmit,
       },
     });
 
@@ -141,20 +141,5 @@ describe("TournamentSettingsForm", () => {
 
     expect(screen.getByText("Name is required")).toBeInTheDocument();
     expect(screen.getByText("Date must be in the future")).toBeInTheDocument();
-  });
-
-  it("shows loading state when submitting", () => {
-    render(TournamentSettingsForm, {
-      props: {
-        tournament: tournament,
-        options: options,
-        featureFlags: featureFlags,
-        isSubmitting: true,
-        submitLabel: "Saving...",
-      },
-    });
-
-    const submitButton = screen.getByRole("button", { name: /saving/i });
-    expect(submitButton).toBeDisabled();
   });
 });

--- a/app/frontend/widgets/ProgressButton.svelte
+++ b/app/frontend/widgets/ProgressButton.svelte
@@ -22,7 +22,7 @@
     inProgressText: string;
     completeText: string;
     confirm?: () => boolean;
-    onclick: () => Promise<void>;
+    onclick: () => void | Promise<void>;
   } = $props();
 
   let state: number = $state(State.DEFAULT);
@@ -42,7 +42,12 @@
   }
 </script>
 
-<button type="button" class={css} onclick={clicked}>
+<button
+  type="button"
+  class={css}
+  onclick={clicked}
+  disabled={state !== State.DEFAULT}
+>
   {#if state === State.IN_PROGRESS}
     <span class="spinner-border spinner-border-sm m-auto"></span>
     {inProgressText}


### PR DESCRIPTION
These changes should resolve the massive amount of binding warnings being generated by the tests.

These warnings were being generated because the `bind:` directive cannot be used with derived variables and bindable props. The best solution I've found for this is to create local copies of editable entities that _can_ be bound to.

I have some thoughts about how to improve the bindings and callbacks that we're currently using but I need to play around with those more before making any changes.

As part of this, I also updated `TournamentSettingsForm` to use the new `ProgressButton` for consistency and because the `isSubmitting` prop was tangled with these changes. I needed to remove two tests that were specifically testing that the save button on that component was disabled when clicked due to the way the `ProgressButton` works - I assume this is low priority and we can figure out a better way to test that sort of thing later.