### PR TITLE
Fixed pairings markdown logic

### DIFF
--- a/app/controllers/pairings_controller.rb
+++ b/app/controllers/pairings_controller.rb
@@ -2,7 +2,7 @@
 
 class PairingsController < ApplicationController # rubocop:disable Metrics/ClassLength,Style/Documentation
   before_action :set_tournament
-  before_action :round, only: %i[sharing markdown]
+  before_action :round, only: %i[sharing]
   attr_reader :tournament
 
   def index
@@ -33,46 +33,6 @@ class PairingsController < ApplicationController # rubocop:disable Metrics/Class
 
   def sharing
     authorize @tournament, :show?
-  end
-
-  def markdown
-    authorize @tournament, :show?
-
-    page_header = "# #{@round.stage.format.titleize} - Round #{@round.number} Pairings"
-
-    # Retrieve pairing data
-    sql = ActiveRecord::Base.sanitize_sql(
-      [
-        'SELECT * FROM summarized_pairings WHERE tournament_id = ? AND round_id = ? ORDER BY table_number',
-        @tournament.id, @round.id
-      ]
-    )
-    rows = ActiveRecord::Base.connection.exec_query(sql).to_a
-
-    # Construct markdown pages
-    pages = []
-    current_page = page_header
-    rows.each do |p|
-      table_md = "\n### Table #{p['table_number']}"
-      table_md += "\n- #{pairing_player_markdown(
-        p['player1_name'], p['player1_pronouns'], p['side'] == Pairing.sides[:player1_is_corp]
-      )}"
-      table_md += "\n- #{pairing_player_markdown(
-        p['player2_name'], p['player2_pronouns'], p['side'] == Pairing.sides[:player2_is_corp]
-      )}"
-
-      # Pages are capped at 2000 characters to fit within a single Discord message
-      if current_page.length + table_md.length >= 2000
-        pages.append(current_page)
-        current_page = page_header
-      end
-
-      current_page += table_md
-    end
-
-    pages.append(current_page)
-
-    render json: { pages: }
   end
 
   def create
@@ -197,12 +157,5 @@ class PairingsController < ApplicationController # rubocop:disable Metrics/Class
     params
       .expect(pairing: %i[score1_runner score1_corp score2_runner score2_corp
                           score1 score2 side intentional_draw two_for_one])
-  end
-
-  def pairing_player_markdown(name, pronouns, is_corp)
-    markdown = "**#{name}**"
-    markdown += " *(#{pronouns})*" if pronouns.present?
-    markdown += " - #{is_corp ? 'Corp' : 'Runner'}" if @round.stage.single_sided?
-    markdown
   end
 end

--- a/app/frontend/pairings/Share.svelte
+++ b/app/frontend/pairings/Share.svelte
@@ -1,24 +1,56 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { SharingData } from "./PairingsData";
-  import { loadSharingData } from "./PairingsData";
   import SharePage from "./SharePage.svelte";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+  import { loadRound, type RoundData } from "./RoundData";
+  import type { Player } from "../players/PlayersData";
 
-  interface Props {
+  let {
+    tournamentId,
+    roundId,
+  }: {
     tournamentId: number;
     roundId: number;
-  }
+  } = $props();
 
-  let { tournamentId, roundId }: Props = $props();
+  const MAX_MARKDOWN_PAGE_LENGTH = 2000;
 
-  let data = $state(new SharingData());
   let betaEnabledCookie: CookieListItem | null = $state(null);
+  let data: RoundData | undefined = $state();
+  let markdownPages: string[] = $state([]);
 
   onMount(async () => {
-    data = await loadSharingData(tournamentId, roundId);
     betaEnabledCookie = await cookieStore.get("beta_enabled");
+    data = await loadRound(tournamentId, roundId);
+
+    // Build markdown pages
+    const pageHeader = `# ${data.stage.format} - Round ${data.round.number} Pairings`;
+    let currentPage = pageHeader;
+    for (const pairing of data.round.pairings) {
+      let tableMarkdown = `\n### Table ${pairing.table_number}`;
+      tableMarkdown += `\n- ${pairingPlayerMarkdown(pairing.player1, data.stage.is_single_sided)}`;
+      tableMarkdown += `\n- ${pairingPlayerMarkdown(pairing.player2, data.stage.is_single_sided)}`;
+
+      if (
+        currentPage.length + tableMarkdown.length >=
+        MAX_MARKDOWN_PAGE_LENGTH
+      ) {
+        markdownPages.push(currentPage);
+        currentPage = pageHeader;
+      }
+
+      currentPage += tableMarkdown;
+    }
+    markdownPages.push(currentPage);
   });
+
+  function pairingPlayerMarkdown(player: Player, isSingleSided: boolean) {
+    let markdown = `**${player.name_with_pronouns}**`;
+    if (isSingleSided) {
+      markdown += ` - ${player.side_label}`;
+    }
+    return markdown;
+  }
 </script>
 
 <p>
@@ -35,7 +67,7 @@
 {#if data}
   <h2>Export Pairings as Markdown</h2>
 
-  {#each data.pages as text, i (i)}
+  {#each markdownPages as text, i (i)}
     <div class="mb-3">
       <SharePage {text} page={i + 1} />
     </div>

--- a/app/frontend/pairings/SharePage.svelte
+++ b/app/frontend/pairings/SharePage.svelte
@@ -2,12 +2,7 @@
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import ProgressButton from "../widgets/ProgressButton.svelte";
 
-  interface Props {
-    text: string;
-    page: number;
-  }
-
-  let { text, page }: Props = $props();
+  let { text, page }: { text: string; page: number } = $props();
 
   let error = $state("");
 


### PR DESCRIPTION
These changes both move the pairings markdown logic to the frontend and use the existing `PairingsData` to generate the markdown (which I don't think existed at the time the markdown page was created).