### PR TITLE
Add self-reporting to the Me tab

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -28,7 +28,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         custom_table_numbering: Flipper.enabled?(:custom_table_numbering, current_user)
       },
       tournament: helpers.tournament_json(@tournament),
-      stages: pairings_data_stages,
+      stages: pairings_data_stages(params[:user_id] ? params[:user_id].to_i : 0),
       warnings: ([@tournament.current_stage&.validate_table_count] if policy(@tournament).update?)
     }
   end
@@ -155,7 +155,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     params.require(:round).permit(:weight)
   end
 
-  def pairings_data_stages
+  def pairings_data_stages(user_id = 0)
     players = pairings_data_players
     @tournament.stages.includes(:rounds, :registrations).map do |stage|
       stage_players = pairings_data_players_with_seeds(players, stage)
@@ -166,7 +166,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         is_single_sided: stage.single_sided?,
         is_elimination: stage.elimination?,
         view_decks: stage.decks_visible_to?(current_user),
-        rounds: pairings_data_rounds(stage, stage_players),
+        rounds: pairings_data_rounds(stage, stage_players, user_id),
         player_count: stage.players.count
       }
     end
@@ -204,7 +204,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     players
   end
 
-  def pairings_data_rounds(stage, players)
+  def pairings_data_rounds(stage, players, user_id = 0)
     self_reports_by_pairing_id = SelfReport.joins(pairing: :round)
                                            .where(rounds: { stage_id: stage.id })
                                            .group_by(&:pairing_id)
@@ -215,11 +215,11 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
 
     # Get data for all paired rounds
     stage.rounds.map do |round|
-      pairings_data_round(stage, players, round, self_reports_by_pairing_id)
+      pairings_data_round(stage, players, round, self_reports_by_pairing_id, user_id)
     end
   end
 
-  def pairings_data_round(stage, players, round, self_reports_by_pairing_id)
+  def pairings_data_round(stage, players, round, self_reports_by_pairing_id, user_id = 0)
     pairings = []
     pairings_reported = 0
     pairings_fields = %i[id table_number player1_id player2_id side intentional_draw
@@ -227,6 +227,11 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     round.pairings.order(:table_number).pluck(pairings_fields).each do | # rubocop:disable Metrics/ParameterLists
     id, table_number, player1_id, player2_id, side, intentional_draw,
       two_for_one, score1, score1_corp, score1_runner, score2, score2_corp, score2_runner|
+      player_1_user_id = players[player1_id]&.dig('user_id')
+      player_2_user_id = players[player2_id]&.dig('user_id')
+
+      next unless user_id.zero? || user_id == player_1_user_id || user_id == player_2_user_id
+
       pairings_reported += score1.nil? && score2.nil? ? 0 : 1
       self_reports = current_user ? self_reports_by_pairing_id[id] : nil
 
@@ -270,8 +275,8 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         policy: {
           self_report: SelfReporting.self_report_allowed(current_user,
                                                          self_reports&.any? ? self_reports[0] : nil,
-                                                         players[player1_id]&.dig('user_id'),
-                                                         players[player2_id]&.dig('user_id')) &&
+                                                         player_1_user_id,
+                                                         player_2_user_id) &&
                        score1.nil? && score2.nil? && @tournament.allow_self_reporting
         },
         # TODO: in future pass current user to svelte frontend
@@ -279,8 +284,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
           row_highlighted: if current_user.nil?
                              false
                            else
-                             current_user.id == players[player1_id]&.dig('user_id') ||
-                             current_user.id == players[player2_id]&.dig('user_id')
+                             [player_1_user_id, player_2_user_id].include?(current_user.id)
                            end
         },
         player1: pairings_data_player(players[player1_id], player1_side(side)),

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -241,7 +241,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
       end
 
       # TODO: Move label logic and score_label() to FE
-      if self_reports&.any? && @tournament.user != current_user
+      if self_reports&.any?
         if stage.single_sided? && side == 'player1_is_corp'
           self_reports.each do |r|
             r[:label] = score_label(@tournament.swiss_format,

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -28,7 +28,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
         custom_table_numbering: Flipper.enabled?(:custom_table_numbering, current_user)
       },
       tournament: helpers.tournament_json(@tournament),
-      stages: pairings_data_stages(params[:user_id] ? params[:user_id].to_i : 0),
+      stages: pairings_data_stages(params[:user_id]&.to_i),
       warnings: ([@tournament.current_stage&.validate_table_count] if policy(@tournament).update?)
     }
   end
@@ -155,7 +155,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     params.require(:round).permit(:weight)
   end
 
-  def pairings_data_stages(user_id = 0)
+  def pairings_data_stages(user_id = nil)
     players = pairings_data_players
     @tournament.stages.includes(:rounds, :registrations).map do |stage|
       stage_players = pairings_data_players_with_seeds(players, stage)
@@ -204,7 +204,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     players
   end
 
-  def pairings_data_rounds(stage, players, user_id = 0)
+  def pairings_data_rounds(stage, players, user_id = nil)
     self_reports_by_pairing_id = SelfReport.joins(pairing: :round)
                                            .where(rounds: { stage_id: stage.id })
                                            .group_by(&:pairing_id)
@@ -219,7 +219,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     end
   end
 
-  def pairings_data_round(stage, players, round, self_reports_by_pairing_id, user_id = 0)
+  def pairings_data_round(stage, players, round, self_reports_by_pairing_id, user_id = nil)
     pairings = []
     pairings_reported = 0
     pairings_fields = %i[id table_number player1_id player2_id side intentional_draw

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -224,13 +224,17 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
     pairings_reported = 0
     pairings_fields = %i[id table_number player1_id player2_id side intentional_draw
                          two_for_one score1 score1_corp score1_runner score2 score2_corp score2_runner]
-    round.pairings.order(:table_number).pluck(pairings_fields).each do | # rubocop:disable Metrics/ParameterLists
+    filtered_pairings = round.pairings.order(:table_number)
+    unless user_id.nil?
+      filtered_pairings = filtered_pairings
+                          .joins(:player1, :player2)
+                          .where('players.user_id = ? or player2s_pairings.user_id = ?', user_id, user_id)
+    end
+    filtered_pairings.pluck(pairings_fields).each do | # rubocop:disable Metrics/ParameterLists
     id, table_number, player1_id, player2_id, side, intentional_draw,
       two_for_one, score1, score1_corp, score1_runner, score2, score2_corp, score2_runner|
       player_1_user_id = players[player1_id]&.dig('user_id')
       player_2_user_id = players[player2_id]&.dig('user_id')
-
-      next unless user_id.zero? || user_id == player_1_user_id || user_id == player_2_user_id
 
       pairings_reported += score1.nil? && score2.nil? ? 0 : 1
       self_reports = current_user ? self_reports_by_pairing_id[id] : nil

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -313,6 +313,20 @@ class TournamentsController < ApplicationController # rubocop:disable Metrics/Cl
           return
         end
       end
+      format.json do
+        if current_user.nil?
+          render json: { error: 'Not authorized' }, status: :unauthorized
+          return
+        end
+
+        player = @tournament.players.find_by(user_id: current_user.id)
+        unless player
+          render json: { error: 'You are not registered in this tournament.' }, status: :unauthorized
+          return
+        end
+
+        render json: SummarizedPairings.for_user_in_tournament(current_user.id, @tournament.id)
+      end
     end
   end
 

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -312,22 +312,6 @@ class TournamentsController < ApplicationController # rubocop:disable Metrics/Cl
                       alert: 'You are not registered in this tournament.'
           return
         end
-
-        @my_tournament_data = SummarizedPairings.for_user_in_tournament(current_user.id, @tournament.id)
-      end
-      format.json do
-        if current_user.nil?
-          render json: { error: 'Not authorized' }, status: :unauthorized
-          return
-        end
-
-        player = @tournament.players.find_by(user_id: current_user.id)
-        unless player
-          render json: { error: 'You are not registered in this tournament.' }, status: :unauthorized
-          return
-        end
-
-        render json: SummarizedPairings.for_user_in_tournament(current_user.id, @tournament.id)
       end
     end
   end

--- a/app/frontend/entrypoints/my_tournament.ts
+++ b/app/frontend/entrypoints/my_tournament.ts
@@ -9,8 +9,7 @@ document.addEventListener("turbolinks:load", function () {
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament-id") ?? "") || -1,
-        userId:
-          Number(anchor.getAttribute("data-user-id") ?? "") || -1,
+        userId: Number(anchor.getAttribute("data-user-id") ?? "") || -1,
       },
     });
   }

--- a/app/frontend/entrypoints/my_tournament.ts
+++ b/app/frontend/entrypoints/my_tournament.ts
@@ -1,17 +1,16 @@
 import { mount } from "svelte";
 import MyTournamentPage from "../tournaments/MyTournamentPage.svelte";
-import type { MyTournamentData } from "../tournaments/TournamentSettings";
 
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("my_tournament_anchor");
   if (anchor?.childNodes.length == 0) {
-    const dataJson = anchor.getAttribute("data-my-tournament") ?? "{}";
-    const data = JSON.parse(dataJson) as MyTournamentData;
-
     mount(MyTournamentPage, {
       target: anchor,
       props: {
-        data: data,
+        tournamentId:
+          Number(anchor.getAttribute("data-tournament-id") ?? "") || -1,
+        userId:
+          Number(anchor.getAttribute("data-user-id") ?? "") || -1,
       },
     });
   }

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -51,17 +51,17 @@ declare const Routes: {
   cut_conversion_rates_beta_tournament_path: (tournamentId: number) => string;
 };
 
-export async function loadPairings(tournamentId: number, userId = 0) {
+export async function loadPairings(tournamentId: number, userId: number | null = null) {
   const betaEnabledCookie = await cookieStore.get("beta_enabled");
 
   let url = "";
-  if (userId === 0) {
+  if (userId) {
+    url = `/tournaments/${tournamentId}/rounds/pairings_data/${userId}`;
+  } else {
     url =
       betaEnabledCookie?.value === "true"
         ? Routes.pairings_data_beta_tournament_rounds_path(tournamentId)
         : Routes.pairings_data_tournament_rounds_path(tournamentId);
-  } else {
-    url = `/tournaments/${tournamentId}/rounds/pairings_data/${userId}`;
   }
 
   const response = await fetch(url, {

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -51,7 +51,10 @@ declare const Routes: {
   cut_conversion_rates_beta_tournament_path: (tournamentId: number) => string;
 };
 
-export async function loadPairings(tournamentId: number, userId: number | null = null) {
+export async function loadPairings(
+  tournamentId: number,
+  userId: number | null = null,
+) {
   const betaEnabledCookie = await cookieStore.get("beta_enabled");
 
   let url = "";

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -56,19 +56,17 @@ export async function loadPairings(tournamentId: number, userId = 0) {
 
   let url = "";
   if (userId === 0) {
-    url = betaEnabledCookie?.value === "true"
-      ? Routes.pairings_data_beta_tournament_rounds_path(tournamentId)
-      : Routes.pairings_data_tournament_rounds_path(tournamentId);
+    url =
+      betaEnabledCookie?.value === "true"
+        ? Routes.pairings_data_beta_tournament_rounds_path(tournamentId)
+        : Routes.pairings_data_tournament_rounds_path(tournamentId);
   } else {
     url = `/tournaments/${tournamentId}/rounds/pairings_data/${userId}`;
   }
 
-  const response = await fetch(
-    url,
-    {
-      method: "GET",
-    },
-  );
+  const response = await fetch(url, {
+    method: "GET",
+  });
 
   const data = (await response.json()) as PairingsData;
   globalMessages.warnings = data.warnings ?? [];

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -51,14 +51,20 @@ declare const Routes: {
   cut_conversion_rates_beta_tournament_path: (tournamentId: number) => string;
 };
 
-export async function loadPairings(
-  tournamentId: number,
-): Promise<PairingsData> {
+export async function loadPairings(tournamentId: number, userId = 0) {
   const betaEnabledCookie = await cookieStore.get("beta_enabled");
-  const response = await fetch(
-    betaEnabledCookie?.value === "true"
+
+  let url = "";
+  if (userId === 0) {
+    url = betaEnabledCookie?.value === "true"
       ? Routes.pairings_data_beta_tournament_rounds_path(tournamentId)
-      : Routes.pairings_data_tournament_rounds_path(tournamentId),
+      : Routes.pairings_data_tournament_rounds_path(tournamentId);
+  } else {
+    url = `/tournaments/${tournamentId}/rounds/pairings_data/${userId}`;
+  }
+
+  const response = await fetch(
+    url,
     {
       method: "GET",
     },

--- a/app/frontend/tests/MyTournamentPage.svelte-test.ts
+++ b/app/frontend/tests/MyTournamentPage.svelte-test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MockPairing1, MockPairingsData, MockSelfReport } from "./RoundsTestData";
+import { getByRole, getByText, queryByRole, render } from "@testing-library/svelte";
+import MyTournamentPage from "../tournaments/MyTournamentPage.svelte";
+import userEvent from "@testing-library/user-event";
+import { loadPairings } from "../pairings/PairingsData";
+import { reportScore } from "../pairings/SelfReport";
+
+const user = userEvent.setup();
+
+vi.mock("../pairings/PairingsData", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../pairings/PairingsData")>()),
+  loadPairings: vi.fn(() => MockPairingsData),
+}));
+
+vi.mock("../pairings/SelfReport", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../pairings/SelfReport")>()),
+  reportScore: vi.fn(() => true),
+}));
+
+describe("MyTournamentPage", () => {
+  const componentProps = { tournamentId: 1, userId: 2 };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(MockPairingsData.policy, "update", "get").mockReturnValue(false);
+  });
+  
+  describe("self-reporting disabled", () => {
+    beforeEach(() => {  
+      render(MyTournamentPage, componentProps);
+    });
+
+    it("does not show the Report Pairing button when self-reporting is not enabled", () => {
+      const table = document.getElementById("rounds_table") as HTMLTableElement;
+      const currentRow = table.rows[table.rows.length - 1];
+      expect(
+        queryByRole(currentRow, "button", { name: /report pairing/i }),
+      ).toBeNull();
+    });
+  });
+  
+  describe("self-reporting enabled", () => {
+    beforeEach(() => {
+      vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(
+        true,
+      );
+
+      render(MyTournamentPage, componentProps);
+    });
+
+    describe.each([
+      [6, 0, /6-0/i, "6 - 0"],
+      [3, 3, /3-3 \(c\)/i, "3 - 3 (c)"],
+      [3, 3, /3-3 \(r\)/i, "3 - 3 (R)"],
+      [6, 0, /0-6/i, "0 - 6"],
+    ])("using preset score", (score1, score2, buttonText, scoreText) => {
+      it(scoreText, async () => {
+        vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(
+          false,
+        );
+        vi.spyOn(MockPairing1, "self_reports", "get").mockReturnValue([
+          MockSelfReport,
+        ]);
+        vi.spyOn(MockSelfReport, "score1", "get").mockReturnValue(score1);
+        vi.spyOn(MockSelfReport, "score2", "get").mockReturnValue(score2);
+        vi.spyOn(MockSelfReport, "label", "get").mockReturnValue(scoreText);
+        
+        const table = document.getElementById("rounds_table") as HTMLTableElement;
+        const currentRow = table.rows[table.rows.length - 1];
+        await user.click(
+          getByRole(currentRow, "button", { name: /report pairing/i }),
+        );
+        
+        const reportDialog = document.getElementById("reportModal");
+        expect(reportDialog).not.toBeNull();
+        if (!reportDialog) {
+          return;
+        }
+        await user.click(getByText(reportDialog, buttonText));
+        
+        expect(reportScore).toHaveBeenCalledOnce();
+        expect(loadPairings).toHaveBeenCalledTimes(2);
+        expect(
+          queryByRole(currentRow, "button", { name: /report pairing/i }),
+        ).toBeNull();
+        expect(getByText(currentRow, `Report: ${scoreText}`)).not.toBeNull();
+      });
+    });
+  });
+});

--- a/app/frontend/tests/MyTournamentPage.svelte-test.ts
+++ b/app/frontend/tests/MyTournamentPage.svelte-test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { MockPairing1, MockPairingsData, MockSelfReport } from "./RoundsTestData";
-import { getByRole, getByText, queryByRole, render } from "@testing-library/svelte";
+import {
+  MockPairing1,
+  MockPairingsData,
+  MockSelfReport,
+} from "./RoundsTestData";
+import {
+  getByRole,
+  getByText,
+  queryByRole,
+  render,
+} from "@testing-library/svelte";
 import MyTournamentPage from "../tournaments/MyTournamentPage.svelte";
 import userEvent from "@testing-library/user-event";
 import { loadPairings } from "../pairings/PairingsData";
@@ -26,9 +35,9 @@ describe("MyTournamentPage", () => {
 
     vi.spyOn(MockPairingsData.policy, "update", "get").mockReturnValue(false);
   });
-  
+
   describe("self-reporting disabled", () => {
-    beforeEach(() => {  
+    beforeEach(() => {
       render(MyTournamentPage, componentProps);
     });
 
@@ -40,12 +49,10 @@ describe("MyTournamentPage", () => {
       ).toBeNull();
     });
   });
-  
+
   describe("self-reporting enabled", () => {
     beforeEach(() => {
-      vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(
-        true,
-      );
+      vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(true);
 
       render(MyTournamentPage, componentProps);
     });
@@ -66,20 +73,22 @@ describe("MyTournamentPage", () => {
         vi.spyOn(MockSelfReport, "score1", "get").mockReturnValue(score1);
         vi.spyOn(MockSelfReport, "score2", "get").mockReturnValue(score2);
         vi.spyOn(MockSelfReport, "label", "get").mockReturnValue(scoreText);
-        
-        const table = document.getElementById("rounds_table") as HTMLTableElement;
+
+        const table = document.getElementById(
+          "rounds_table",
+        ) as HTMLTableElement;
         const currentRow = table.rows[table.rows.length - 1];
         await user.click(
           getByRole(currentRow, "button", { name: /report pairing/i }),
         );
-        
+
         const reportDialog = document.getElementById("reportModal");
         expect(reportDialog).not.toBeNull();
         if (!reportDialog) {
           return;
         }
         await user.click(getByText(reportDialog, buttonText));
-        
+
         expect(reportScore).toHaveBeenCalledOnce();
         expect(loadPairings).toHaveBeenCalledTimes(2);
         expect(

--- a/app/frontend/tests/Rounds.svelte-test.ts
+++ b/app/frontend/tests/Rounds.svelte-test.ts
@@ -670,7 +670,7 @@ describe("Rounds", () => {
         )[0] as HTMLElement;
         expect(
           queryByRole(table1Row, "button", { name: /report pairing/i }),
-        ).not.toBeTruthy();
+        ).toBeNull();
       });
     });
 
@@ -718,8 +718,8 @@ describe("Rounds", () => {
           expect(loadPairings).toHaveBeenCalledTimes(2);
           expect(
             queryByRole(table1Row, "button", { name: /report pairing/i }),
-          ).not.toBeTruthy();
-          expect(getByText(table1Row, `Report: ${scoreText}`)).toBeTruthy();
+          ).toBeNull();
+          expect(getByText(table1Row, `Report: ${scoreText}`)).not.toBeNull();
         });
       });
     });

--- a/app/frontend/tests/RoundsTestData.ts
+++ b/app/frontend/tests/RoundsTestData.ts
@@ -16,7 +16,7 @@ export const MockPlayerAlice: Player = {
   pronouns: "she/her",
   name_with_pronouns: "Alice (she/her)",
   side: null,
-  user_id: 0,
+  user_id: 1,
   side_label: null,
   corp_id: new Identity(),
   runner_id: new Identity(),
@@ -34,7 +34,7 @@ export const MockPlayerBob: Player = {
   pronouns: "he/him",
   name_with_pronouns: "Bob (he/him)",
   side: null,
-  user_id: 0,
+  user_id: 2,
   side_label: null,
   corp_id: {
     name: "BANGUN: When Disaster Strikes",

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -114,9 +114,9 @@
           </thead>
           <tbody>
             {#each data.stages as stage (stage.id)}
-              {#each stage.rounds as round (round.id)}
-                {#each round.pairings as pairing, idx (pairing.id)}
-                  {#if showPreviousRounds || idx === pairingCount - 1}
+              {#each stage.rounds as round, idx (round.id)}
+                {#if showPreviousRounds || idx === stage.rounds.length - 1}
+                  {#each round.pairings as pairing (pairing.id)}
                     <tr>
                       <td>
                         {stage.is_elimination ? "Cut " : ""}{round.number}
@@ -181,8 +181,8 @@
                         {/if}
                       </td>
                     </tr>
-                  {/if}
-                {/each}
+                  {/each}
+                {/if}
               {/each}
             {/each}
           </tbody>

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -1,17 +1,33 @@
 <script lang="ts">
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import { onMount } from "svelte";
-  import { loadPairings, PairingsData, type Pairing } from "../pairings/PairingsData";
+  import {
+    loadPairings,
+    PairingsData,
+    type Pairing,
+  } from "../pairings/PairingsData";
   import PlayerDisplay from "../pairings/PlayerDisplay.svelte";
   import SelfReportOptions from "../pairings/SelfReportOptions.svelte";
   import { reportScore, type ScoreReport } from "../pairings/SelfReport";
 
-  let { tournamentId, userId }: { tournamentId: number, userId: number } = $props();
+  let {
+    tournamentId,
+    userId,
+  }: {
+    tournamentId: number;
+    userId: number;
+  } = $props();
 
   let data: PairingsData | undefined = $state();
   let showPreviousRounds = $state(false);
   let pairingCount = $derived(
-    data ? data.stages.reduce((acc, s) => acc + s.rounds.reduce((acc, r) => acc + r.pairings.length, 0), 0) : 0
+    data
+      ? data.stages.reduce(
+          (acc, s) =>
+            acc + s.rounds.reduce((acc, r) => acc + r.pairings.length, 0),
+          0,
+        )
+      : 0,
   );
 
   onMount(async () => {
@@ -23,11 +39,19 @@
   }
 
   function getMySide(pairing: Pairing) {
-    const side = pairing.player1.user_id === userId ? pairing.player1.side : pairing.player2.side;
-    return side ? (side.charAt(0).toUpperCase() + side.slice(1)) : "";
+    const side =
+      pairing.player1.user_id === userId
+        ? pairing.player1.side
+        : pairing.player2.side;
+    return side ? side.charAt(0).toUpperCase() + side.slice(1) : "";
   }
 
-  async function reportScoreCallback(roundId: number, pairingId: number, report: ScoreReport, selfReport: boolean) {
+  async function reportScoreCallback(
+    roundId: number,
+    pairingId: number,
+    report: ScoreReport,
+    selfReport: boolean,
+  ) {
     const success = await reportScore(
       tournamentId,
       roundId,
@@ -74,7 +98,7 @@
           </div>
         </div>
       {/if}
-  
+
       <div class="row col-12 table-responsive">
         <table class="table">
           <thead>
@@ -94,7 +118,9 @@
                 {#each round.pairings as pairing, idx (pairing.id)}
                   {#if showPreviousRounds || idx === pairingCount - 1}
                     <tr>
-                      <td>{stage.is_elimination ? "Cut " : ""}{round.number}</td>
+                      <td>
+                        {stage.is_elimination ? "Cut " : ""}{round.number}
+                      </td>
                       <td>{isBye(pairing) ? "" : pairing.table_number}</td>
                       {#if stage.is_single_sided}
                         <td>{isBye(pairing) ? "" : getMySide(pairing)}</td>
@@ -104,7 +130,9 @@
                           (Bye)
                         {:else}
                           <PlayerDisplay
-                            player={pairing.player1.user_id === userId ? pairing.player2 : pairing.player1}
+                            player={pairing.player1.user_id === userId
+                              ? pairing.player2
+                              : pairing.player1}
                             {pairing}
                             left_or_right="left"
                             is_single_sided={stage.is_single_sided}
@@ -115,11 +143,18 @@
                         {#if pairing.score_label.trim() !== "-"}
                           {pairing.score_label}
                           {#if pairing.intentional_draw}
-                            <span class="badge badge-pill badge-secondary score-badge">ID</span>
+                            <span
+                              class="badge badge-pill badge-secondary score-badge"
+                            >
+                              ID
+                            </span>
                           {/if}
                           {#if pairing.two_for_one}
-                            <span class="badge badge-pill badge-secondary score-badge">2 for 1</span
+                            <span
+                              class="badge badge-pill badge-secondary score-badge"
                             >
+                              2 for 1
+                            </span>
                           {/if}
                         {:else}
                           {#if pairing.policy.self_report}
@@ -131,7 +166,12 @@
                                 report: ScoreReport,
                                 selfReport: boolean,
                               ) => {
-                                await reportScoreCallback(round.id, pairingId, report, selfReport);
+                                await reportScoreCallback(
+                                  round.id,
+                                  pairingId,
+                                  report,
+                                  selfReport,
+                                );
                               }}
                             />
                           {/if}

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -1,148 +1,157 @@
 <script lang="ts">
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
-  import Identity from "../identities/Identity.svelte";
-  import type {
-    MyTournamentData,
-    MyTournamentPairing,
-  } from "./TournamentSettings";
+  import { onMount } from "svelte";
+  import { loadPairings, PairingsData, type Pairing } from "../pairings/PairingsData";
+  import PlayerDisplay from "../pairings/PlayerDisplay.svelte";
+  import SelfReportOptions from "../pairings/SelfReportOptions.svelte";
+  import { reportScore, type ScoreReport } from "../pairings/SelfReport";
 
-  let { data }: { data: MyTournamentData } = $props();
+  let { tournamentId, userId }: { tournamentId: number, userId: number } = $props();
 
+  let data: PairingsData | undefined = $state();
   let showPreviousRounds = $state(false);
-
-  function isBye(pairing: MyTournamentPairing): boolean {
-    return !pairing.opponent.name || pairing.opponent.name === "";
-  }
-
-  function getMySide(pairing: MyTournamentPairing): "Corp" | "Runner" | null {
-    if (
-      pairing.format !== "single_sided_swiss" &&
-      !pairing.format.includes("elim")
-    )
-      return null;
-    if (pairing.side === 1) return "Corp";
-    if (pairing.side === 2) return "Runner";
-    return null;
-  }
-
-  function getRoundLabel(pairing: MyTournamentPairing): string {
-    const prefix = pairing.format.includes("elim") ? "Cut " : "";
-    return `${prefix}${String(pairing.round_number)}`;
-  }
-
-  const hasSideCol = $derived(
-    (data.pairings ?? []).some(
-      (p) => p.format === "single_sided_swiss" || p.format.includes("elim"),
-    ),
+  let pairingCount = $derived(
+    data ? data.stages.reduce((acc, s) => acc + s.rounds.reduce((acc, r) => acc + r.pairings.length, 0), 0) : 0
   );
+
+  onMount(async () => {
+    data = await loadPairings(tournamentId, userId);
+  });
+
+  function isBye(pairing: Pairing): boolean {
+    return pairing.player1.id === 0 || pairing.player2.id === 0;
+  }
+
+  function getMySide(pairing: Pairing) {
+    const side = pairing.player1.user_id === userId ? pairing.player1.side : pairing.player2.side;
+    return side ? (side.charAt(0).toUpperCase() + side.slice(1)) : "";
+  }
+
+  async function reportScoreCallback(roundId: number, pairingId: number, report: ScoreReport, selfReport: boolean) {
+    const success = await reportScore(
+      tournamentId,
+      roundId,
+      pairingId,
+      report,
+      selfReport,
+    );
+    if (!success) {
+      return;
+    }
+
+    data = await loadPairings(tournamentId, userId);
+  }
 </script>
 
-<div class="container">
-  <h2>Me</h2>
-  {#if !data.pairings || data.pairings.length === 0}
-    <div class="row">
-      <div class="col-12">
-        <div class="alert alert-info">
-          <FontAwesomeIcon icon="info-circle" />
-          You don't have any pairings in this tournament yet.
-        </div>
-      </div>
-    </div>
-  {:else}
-    {#if data.pairings.length > 1}
+{#if data}
+  <div class="container">
+    <h2>Me</h2>
+
+    {#if pairingCount === 0}
       <div class="row">
         <div class="col-12">
-          <button
-            class="btn btn-link btn-sm p-0 mb-2 d-flex align-items-center small"
-            onclick={() => (showPreviousRounds = !showPreviousRounds)}
-          >
-            <FontAwesomeIcon
-              icon={showPreviousRounds ? "chevron-down" : "chevron-right"}
-            />
-            <span class="ml-2">
-              {showPreviousRounds ? "Hide" : "Show"} previous rounds
-            </span>
-          </button>
+          <div class="alert alert-info">
+            <FontAwesomeIcon icon="info-circle" />
+            You don't have any pairings in this tournament yet.
+          </div>
         </div>
       </div>
-    {/if}
-
-    <div class="row col-12 table-responsive">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Round</th>
-            <th>Table</th>
-            {#if hasSideCol}
-              <th>Side</th>
-            {/if}
-            <th>Opponent</th>
-            <th class="text-center">Score</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each data.pairings as pairing, idx (pairing.pairing_id)}
-            {#if showPreviousRounds || idx === data.pairings.length - 1}
-              {@const mySide = getMySide(pairing)}
-              <tr>
-                <td>{getRoundLabel(pairing)}</td>
-                <td>{isBye(pairing) ? "" : (pairing.table_number ?? "")}</td>
-                {#if hasSideCol}
-                  <td>{isBye(pairing) ? "" : (mySide ?? "")}</td>
-                {/if}
-                <td>
-                  {#if isBye(pairing)}
-                    (Bye)
-                  {:else}
-                    <div>{pairing.opponent.name_with_pronouns}</div>
-                    <div class="ids small text-muted">
-                      {#if mySide}
-                        {#if mySide === "Corp" && pairing.opponent.runner_identity}
-                          <Identity
-                            identity={{
-                              name: pairing.opponent.runner_identity,
-                              faction: pairing.opponent.runner_faction ?? "",
-                            }}
-                          />
-                        {:else if mySide === "Runner" && pairing.opponent.corp_identity}
-                          <Identity
-                            identity={{
-                              name: pairing.opponent.corp_identity,
-                              faction: pairing.opponent.corp_faction ?? "",
-                            }}
+    {:else}
+      {#if pairingCount > 1}
+        <div class="row">
+          <div class="col-12">
+            <button
+              class="btn btn-link btn-sm p-0 mb-2 d-flex align-items-center small"
+              onclick={() => (showPreviousRounds = !showPreviousRounds)}
+            >
+              <FontAwesomeIcon
+                icon={showPreviousRounds ? "chevron-down" : "chevron-right"}
+              />
+              <span class="ml-2">
+                {showPreviousRounds ? "Hide" : "Show"} previous rounds
+              </span>
+            </button>
+          </div>
+        </div>
+      {/if}
+  
+      <div class="row col-12 table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Round</th>
+              <th>Table</th>
+              {#if data.tournament.swiss_format === "single_sided"}
+                <th>Side</th>
+              {/if}
+              <th>Opponent</th>
+              <th class="text-center">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each data.stages as stage (stage.id)}
+              {#each stage.rounds as round (round.id)}
+                {#each round.pairings as pairing, idx (pairing.id)}
+                  {#if showPreviousRounds || idx === pairingCount - 1}
+                    <tr>
+                      <td>{stage.is_elimination ? "Cut " : ""}{round.number}</td>
+                      <td>{isBye(pairing) ? "" : pairing.table_number}</td>
+                      {#if stage.is_single_sided}
+                        <td>{isBye(pairing) ? "" : getMySide(pairing)}</td>
+                      {/if}
+                      <td>
+                        {#if isBye(pairing)}
+                          (Bye)
+                        {:else}
+                          <PlayerDisplay
+                            player={pairing.player1.user_id === userId ? pairing.player2 : pairing.player1}
+                            {pairing}
+                            left_or_right="left"
+                            is_single_sided={stage.is_single_sided}
                           />
                         {/if}
-                      {:else if pairing.opponent.corp_identity && pairing.opponent.runner_identity}
-                        <Identity
-                          identity={{
-                            name: pairing.opponent.corp_identity,
-                            faction: pairing.opponent.corp_faction ?? "",
-                          }}
-                        />
-                        <Identity
-                          identity={{
-                            name: pairing.opponent.runner_identity,
-                            faction: pairing.opponent.runner_faction ?? "",
-                          }}
-                        />
-                      {/if}
-                    </div>
+                      </td>
+                      <td class="text-center">
+                        {#if pairing.score_label.trim() !== "-"}
+                          {pairing.score_label}
+                          {#if pairing.intentional_draw}
+                            <span class="badge badge-pill badge-secondary score-badge">ID</span>
+                          {/if}
+                          {#if pairing.two_for_one}
+                            <span class="badge badge-pill badge-secondary score-badge">2 for 1</span
+                            >
+                          {/if}
+                        {:else}
+                          {#if pairing.policy.self_report}
+                            <SelfReportOptions
+                              {stage}
+                              {pairing}
+                              reportScoreCallback={async (
+                                pairingId: number,
+                                report: ScoreReport,
+                                selfReport: boolean,
+                              ) => {
+                                await reportScoreCallback(round.id, pairingId, report, selfReport);
+                              }}
+                            />
+                          {/if}
+                          {#if pairing.self_reports && pairing.self_reports.length !== 0}
+                            Report: {pairing.self_reports[0].label}
+                          {/if}
+                        {/if}
+                      </td>
+                    </tr>
                   {/if}
-                </td>
-                <td class="text-center">
-                  {#if isBye(pairing)}
-                    {#if pairing.player_score !== null}
-                      {pairing.player_score}
-                    {/if}
-                  {:else if pairing.player_score !== null || pairing.opponent_score !== null}
-                    {pairing.player_score ?? 0} - {pairing.opponent_score ?? 0}
-                  {/if}
-                </td>
-              </tr>
-            {/if}
-          {/each}
-        </tbody>
-      </table>
-    </div>
-  {/if}
-</div>
+                {/each}
+              {/each}
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </div>
+{:else}
+  <div class="d-flex align-items-center m-2">
+    <div class="spinner-border m-auto"></div>
+  </div>
+{/if}

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -113,77 +113,79 @@
             </tr>
           </thead>
           <tbody>
-            {#each data.stages as stage (stage.id)}
-              {#each stage.rounds as round, idx (round.id)}
-                {#if showPreviousRounds || idx === stage.rounds.length - 1}
-                  {#each round.pairings as pairing (pairing.id)}
-                    <tr>
-                      <td>
-                        {stage.is_elimination ? "Cut " : ""}{round.number}
-                      </td>
-                      <td>{isBye(pairing) ? "" : pairing.table_number}</td>
-                      {#if stage.is_single_sided}
-                        <td>{isBye(pairing) ? "" : getMySide(pairing)}</td>
-                      {/if}
-                      <td>
-                        {#if isBye(pairing)}
-                          (Bye)
-                        {:else}
-                          <PlayerDisplay
-                            player={pairing.player1.user_id === userId
-                              ? pairing.player2
-                              : pairing.player1}
-                            {pairing}
-                            left_or_right="left"
-                            is_single_sided={stage.is_single_sided}
-                          />
+            {#each data.stages as stage, stageIdx (stage.id)}
+              {#if showPreviousRounds || stageIdx == data.stages.length - 1}
+                {#each stage.rounds as round, roundIdx (round.id)}
+                  {#if showPreviousRounds || roundIdx === stage.rounds.length - 1}
+                    {#each round.pairings as pairing (pairing.id)}
+                      <tr>
+                        <td>
+                          {stage.is_elimination ? "Cut " : ""}{round.number}
+                        </td>
+                        <td>{isBye(pairing) ? "" : pairing.table_number}</td>
+                        {#if stage.is_single_sided}
+                          <td>{isBye(pairing) ? "" : getMySide(pairing)}</td>
                         {/if}
-                      </td>
-                      <td class="text-center">
-                        {#if pairing.score_label.trim() !== "" && pairing.score_label.trim() !== "-"}
-                          {pairing.score_label}
-                          {#if pairing.intentional_draw}
-                            <span
-                              class="badge badge-pill badge-secondary score-badge"
-                            >
-                              ID
-                            </span>
-                          {/if}
-                          {#if pairing.two_for_one}
-                            <span
-                              class="badge badge-pill badge-secondary score-badge"
-                            >
-                              2 for 1
-                            </span>
-                          {/if}
-                        {:else}
-                          {#if pairing.policy.self_report}
-                            <SelfReportOptions
-                              {stage}
+                        <td>
+                          {#if isBye(pairing)}
+                            (Bye)
+                          {:else}
+                            <PlayerDisplay
+                              player={pairing.player1.user_id === userId
+                                ? pairing.player2
+                                : pairing.player1}
                               {pairing}
-                              reportScoreCallback={async (
-                                pairingId: number,
-                                report: ScoreReport,
-                                selfReport: boolean,
-                              ) => {
-                                await reportScoreCallback(
-                                  round.id,
-                                  pairingId,
-                                  report,
-                                  selfReport,
-                                );
-                              }}
+                              left_or_right="left"
+                              is_single_sided={stage.is_single_sided}
                             />
                           {/if}
-                          {#if pairing.self_reports && pairing.self_reports.length !== 0}
-                            Report: {pairing.self_reports[0].label}
+                        </td>
+                        <td class="text-center">
+                          {#if pairing.score_label.trim() !== "" && pairing.score_label.trim() !== "-"}
+                            {pairing.score_label}
+                            {#if pairing.intentional_draw}
+                              <span
+                                class="badge badge-pill badge-secondary score-badge"
+                              >
+                                ID
+                              </span>
+                            {/if}
+                            {#if pairing.two_for_one}
+                              <span
+                                class="badge badge-pill badge-secondary score-badge"
+                              >
+                                2 for 1
+                              </span>
+                            {/if}
+                          {:else}
+                            {#if pairing.policy.self_report}
+                              <SelfReportOptions
+                                {stage}
+                                {pairing}
+                                reportScoreCallback={async (
+                                  pairingId: number,
+                                  report: ScoreReport,
+                                  selfReport: boolean,
+                                ) => {
+                                  await reportScoreCallback(
+                                    round.id,
+                                    pairingId,
+                                    report,
+                                    selfReport,
+                                  );
+                                }}
+                              />
+                            {/if}
+                            {#if pairing.self_reports && pairing.self_reports.length !== 0}
+                              Report: {pairing.self_reports[0].label}
+                            {/if}
                           {/if}
-                        {/if}
-                      </td>
-                    </tr>
-                  {/each}
-                {/if}
-              {/each}
+                        </td>
+                      </tr>
+                    {/each}
+                  {/if}
+                {/each}
+              {/if}
             {/each}
           </tbody>
         </table>

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -59,97 +59,90 @@
             <FontAwesomeIcon
               icon={showPreviousRounds ? "chevron-down" : "chevron-right"}
             />
-            <span class="ml-2"
-              >{showPreviousRounds ? "Hide" : "Show"} previous rounds</span
-            >
+            <span class="ml-2">
+              {showPreviousRounds ? "Hide" : "Show"} previous rounds
+            </span>
           </button>
         </div>
       </div>
     {/if}
 
-    <div class="row">
-      <div class="col-12">
-        <div class="table-responsive">
-          <table class="table">
-            <thead>
+    <div class="row col-12 table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Round</th>
+            <th>Table</th>
+            {#if hasSideCol}
+              <th>Side</th>
+            {/if}
+            <th>Opponent</th>
+            <th class="text-center">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.pairings as pairing, idx (pairing.pairing_id)}
+            {#if showPreviousRounds || idx === data.pairings.length - 1}
+              {@const mySide = getMySide(pairing)}
               <tr>
-                <th>Round</th>
-                <th>Table</th>
+                <td>{getRoundLabel(pairing)}</td>
+                <td>{isBye(pairing) ? "" : (pairing.table_number ?? "")}</td>
                 {#if hasSideCol}
-                  <th>Side</th>
+                  <td>{isBye(pairing) ? "" : (mySide ?? "")}</td>
                 {/if}
-                <th>Opponent</th>
-                <th class="text-center">Score</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each data.pairings as pairing, idx (pairing.pairing_id)}
-                {#if showPreviousRounds || idx === data.pairings.length - 1}
-                  {@const mySide = getMySide(pairing)}
-                  <tr>
-                    <td>{getRoundLabel(pairing)}</td>
-                    <td>{isBye(pairing) ? "" : (pairing.table_number ?? "")}</td
-                    >
-                    {#if hasSideCol}
-                      <td>{isBye(pairing) ? "" : (mySide ?? "")}</td>
-                    {/if}
-                    <td>
-                      {#if isBye(pairing)}
-                        (Bye)
-                      {:else}
-                        <div>{pairing.opponent.name_with_pronouns}</div>
-                        <div class="ids small text-muted">
-                          {#if mySide}
-                            {#if mySide === "Corp" && pairing.opponent.runner_identity}
-                              <Identity
-                                identity={{
-                                  name: pairing.opponent.runner_identity,
-                                  faction:
-                                    pairing.opponent.runner_faction ?? "",
-                                }}
-                              />
-                            {:else if mySide === "Runner" && pairing.opponent.corp_identity}
-                              <Identity
-                                identity={{
-                                  name: pairing.opponent.corp_identity,
-                                  faction: pairing.opponent.corp_faction ?? "",
-                                }}
-                              />
-                            {/if}
-                          {:else if pairing.opponent.corp_identity && pairing.opponent.runner_identity}
-                            <Identity
-                              identity={{
-                                name: pairing.opponent.corp_identity,
-                                faction: pairing.opponent.corp_faction ?? "",
-                              }}
-                            />
-                            <Identity
-                              identity={{
-                                name: pairing.opponent.runner_identity,
-                                faction: pairing.opponent.runner_faction ?? "",
-                              }}
-                            />
-                          {/if}
-                        </div>
-                      {/if}
-                    </td>
-                    <td class="text-center">
-                      {#if isBye(pairing)}
-                        {#if pairing.player_score !== null}
-                          {pairing.player_score}
+                <td>
+                  {#if isBye(pairing)}
+                    (Bye)
+                  {:else}
+                    <div>{pairing.opponent.name_with_pronouns}</div>
+                    <div class="ids small text-muted">
+                      {#if mySide}
+                        {#if mySide === "Corp" && pairing.opponent.runner_identity}
+                          <Identity
+                            identity={{
+                              name: pairing.opponent.runner_identity,
+                              faction: pairing.opponent.runner_faction ?? "",
+                            }}
+                          />
+                        {:else if mySide === "Runner" && pairing.opponent.corp_identity}
+                          <Identity
+                            identity={{
+                              name: pairing.opponent.corp_identity,
+                              faction: pairing.opponent.corp_faction ?? "",
+                            }}
+                          />
                         {/if}
-                      {:else if pairing.player_score !== null || pairing.opponent_score !== null}
-                        {pairing.player_score ?? 0} - {pairing.opponent_score ??
-                          0}
+                      {:else if pairing.opponent.corp_identity && pairing.opponent.runner_identity}
+                        <Identity
+                          identity={{
+                            name: pairing.opponent.corp_identity,
+                            faction: pairing.opponent.corp_faction ?? "",
+                          }}
+                        />
+                        <Identity
+                          identity={{
+                            name: pairing.opponent.runner_identity,
+                            faction: pairing.opponent.runner_faction ?? "",
+                          }}
+                        />
                       {/if}
-                    </td>
-                  </tr>
-                {/if}
-              {/each}
-            </tbody>
-          </table>
-        </div>
-      </div>
+                    </div>
+                  {/if}
+                </td>
+                <td class="text-center">
+                  {#if isBye(pairing)}
+                    {#if pairing.player_score !== null}
+                      {pairing.player_score}
+                    {/if}
+                  {:else if pairing.player_score !== null || pairing.opponent_score !== null}
+                    {pairing.player_score ?? 0} - {pairing.opponent_score ?? 0}
+                  {/if}
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
     </div>
   {/if}
 </div>

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -100,7 +100,7 @@
       {/if}
 
       <div class="row col-12 table-responsive">
-        <table class="table">
+        <table id="rounds_table" class="table">
           <thead>
             <tr>
               <th>Round</th>
@@ -140,7 +140,7 @@
                         {/if}
                       </td>
                       <td class="text-center">
-                        {#if pairing.score_label.trim() !== "-"}
+                        {#if pairing.score_label.trim() !== "" && pairing.score_label.trim() !== "-"}
                           {pairing.score_label}
                           {#if pairing.intentional_draw}
                             <span

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -1,4 +1,3 @@
-import type { Identity } from "../identities/Identity";
 import type { Player } from "../players/PlayersData";
 
 export type Errors = Record<string, string[]>;
@@ -128,47 +127,6 @@ export interface TournamentSettingsData {
   options: TournamentOptions;
   feature_flags: FeatureFlags;
   csrf_token: string;
-}
-
-export interface MyTournamentPlayer {
-  user_id: number | null;
-  name: string | null;
-  pronouns: string | null;
-  name_with_pronouns: string;
-  corp_identity: string | null;
-  corp_faction: string | null;
-  runner_identity: string | null;
-  runner_faction: string | null;
-}
-
-export interface MyTournamentPairing {
-  stage_id: number;
-  stage_number: number;
-  format: string;
-  round_number: number;
-  round_completed: boolean;
-  pairing_id: number;
-  table_number: number | null;
-  side: string | number | null;
-  opponent: MyTournamentPlayer;
-  player_score: number | null;
-  opponent_score: number | null;
-  player_score_corp: number | null;
-  player_score_runner: number | null;
-  opponent_score_corp: number | null;
-  opponent_score_runner: number | null;
-  intentional_draw: boolean;
-  two_for_one: boolean;
-}
-
-export interface MyTournamentData {
-  tournament_id: number;
-  user_id: number;
-  identities?: {
-    corp: Identity;
-    runner: Identity;
-  };
-  pairings?: MyTournamentPairing[];
 }
 
 export function emptyTournamentOptions(): TournamentOptions {

--- a/app/views/tournaments/my_tournament.html.slim
+++ b/app/views/tournaments/my_tournament.html.slim
@@ -1,4 +1,4 @@
-#my_tournament_anchor.col-12 data-tournament-id="#{@tournament.id}" data-tournament-url="#{tournament_path(@tournament)}" data-my-tournament="#{@my_tournament_data.to_json}"
+#my_tournament_anchor.col-12 data-tournament-id="#{@tournament.id}" data-user-id="#{current_user.id}"
 
 = content_for :head do
   = vite_typescript_tag 'my_tournament', 'data-turbolinks-track': 'reload'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
       patch :complete, on: :member
       patch :update_timer, on: :member
       get :view_pairings, on: :collection
+      get :pairings_data, on: :collection
       get 'pairings_data(/:user_id)', on: :collection, action: 'pairings_data'
       get :brackets, on: :collection
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
       patch :complete, on: :member
       patch :update_timer, on: :member
       get :view_pairings, on: :collection
-      get :pairings_data, on: :collection
+      get 'pairings_data(/:user_id)', on: :collection, action: 'pairings_data'
       get :brackets, on: :collection
     end
     get :bracket, on: :member


### PR DESCRIPTION
In order to minimize excessive code duplication, I took the opportunity to bring the page more in line with what the rest of the app has been doing since the page was first created. Specifically, this page is basically just a mini, personalized version of the Pairings tab now, since it's showing more or less the same information filtered for only a single player. So, while the overall shape of the page is largely the same, it was reworked to use the same data and components as the Rounds and Pairing components.
<img width="1371" height="332" alt="image" src="https://github.com/user-attachments/assets/5adea45a-e179-4460-802b-fa4f628fb2bf" />

The existing pairings_data route was already providing everything we needed and is kind of a bear at the moment, so instead of trying to recreate a narrower version of that I added an optional parameter to it that causes it to return the pairings data for only a specific user. This might be a bit kludgy but it felt like the best option for now, and this code is due for a refactor in the future, anyway.

The tests are extremely simple and copied from the Rounds component tests since we already had self-reporting tests there.