### PR TITLE
Fix the player view for TOs on the Pairings tab

### DIFF
--- a/app/frontend/entrypoints/rounds.ts
+++ b/app/frontend/entrypoints/rounds.ts
@@ -4,14 +4,12 @@ import Rounds from "../pairings/Rounds.svelte";
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("rounds_anchor");
   if (anchor?.childNodes.length == 0) {
-    const forcePlayerView = anchor.getAttribute("data-force-player-view");
     mount(Rounds, {
       target: anchor,
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament") ?? "") || -1,
-        betaVersion: forcePlayerView !== "true",
-        playerView: forcePlayerView === "true",
+        classicVersion: anchor.getAttribute("data-classic-version") === "true",
       },
     });
   }

--- a/app/frontend/entrypoints/rounds.ts
+++ b/app/frontend/entrypoints/rounds.ts
@@ -4,12 +4,14 @@ import Rounds from "../pairings/Rounds.svelte";
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("rounds_anchor");
   if (anchor?.childNodes.length == 0) {
+    const forcePlayerView = anchor.getAttribute("data-force-player-view");
     mount(Rounds, {
       target: anchor,
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament") ?? "") || -1,
-        playerView: anchor.getAttribute("data-force-player-view") === "true",
+        betaVersion: forcePlayerView !== "true",
+        playerView: forcePlayerView === "true",
       },
     });
   }

--- a/app/frontend/entrypoints/rounds.ts
+++ b/app/frontend/entrypoints/rounds.ts
@@ -9,6 +9,7 @@ document.addEventListener("turbolinks:load", function () {
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament") ?? "") || -1,
+        playerView: anchor.getAttribute("data-force-player-view") === "true",
       },
     });
   }

--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -27,9 +27,11 @@
 
   let {
     tournamentId,
+    betaVersion = true,
     playerView,
   }: {
     tournamentId: number;
+    betaVersion?: boolean;
     playerView: boolean;
   } = $props();
 
@@ -47,6 +49,10 @@
   function toggleForcePlayerView() {
     forcePlayerView = !forcePlayerView;
     ctx.showOrganizerView = data.policy.update && !forcePlayerView;
+
+    if (!betaVersion) {
+      window.location.href = `/tournaments/${tournamentId}/rounds`;
+    }
   }
 
   async function addStage(cutSingleElim?: boolean, cutCount?: number) {

--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -25,7 +25,13 @@
     type ScoreReport,
   } from "./SelfReport";
 
-  let { tournamentId }: { tournamentId: number } = $props();
+  let {
+    tournamentId,
+    playerView,
+  }: {
+    tournamentId: number;
+    playerView: boolean;
+  } = $props();
 
   let data = $state(new PairingsData());
   let forcePlayerView = $state(false);
@@ -35,7 +41,7 @@
 
   onMount(async () => {
     data = await loadPairings(tournamentId);
-    ctx.showOrganizerView = data.policy.update;
+    ctx.showOrganizerView = !playerView && data.policy.update;
   });
 
   function toggleForcePlayerView() {

--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -27,12 +27,10 @@
 
   let {
     tournamentId,
-    betaVersion = true,
-    playerView,
+    classicVersion = false,
   }: {
     tournamentId: number;
-    betaVersion?: boolean;
-    playerView: boolean;
+    classicVersion?: boolean;
   } = $props();
 
   let data = $state(new PairingsData());
@@ -43,14 +41,14 @@
 
   onMount(async () => {
     data = await loadPairings(tournamentId);
-    ctx.showOrganizerView = !playerView && data.policy.update;
+    ctx.showOrganizerView = !classicVersion && data.policy.update;
   });
 
   function toggleForcePlayerView() {
     forcePlayerView = !forcePlayerView;
     ctx.showOrganizerView = data.policy.update && !forcePlayerView;
 
-    if (!betaVersion) {
+    if (classicVersion) {
       window.location.href = `/tournaments/${tournamentId}/rounds`;
     }
   }

--- a/app/views/rounds/view_pairings.html.slim
+++ b/app/views/rounds/view_pairings.html.slim
@@ -1,4 +1,4 @@
-#rounds_anchor.col-12 data-tournament="#{@tournament.id}" data-force-player-view="true"
+#rounds_anchor.col-12 data-tournament="#{@tournament.id}" data-classic-version="true"
 
 = content_for :head do
   = vite_typescript_tag 'rounds', 'data-turbolinks-track': 'reload'

--- a/app/views/rounds/view_pairings.html.slim
+++ b/app/views/rounds/view_pairings.html.slim
@@ -1,4 +1,4 @@
-#rounds_anchor.col-12 data-tournament="#{@tournament.id}"
+#rounds_anchor.col-12 data-tournament="#{@tournament.id}" data-force-player-view="true"
 
 = content_for :head do
   = vite_typescript_tag 'rounds', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
Navigating to and from the player view as a TO on the classic Pairings tab now works properly (the user is properly redirected between the /rounds and /view_pairings endpoints).