### PR TITLE
Update layout for the markdown pairings export.

### DIFF
--- a/app/frontend/entrypoints/share_pairings.ts
+++ b/app/frontend/entrypoints/share_pairings.ts
@@ -1,10 +1,10 @@
 import { mount } from "svelte";
-import StageSettings from "../pairings/Share.svelte";
+import Share from "../pairings/Share.svelte";
 
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("share_pairings_anchor");
   if (anchor?.childNodes.length === 0) {
-    mount(StageSettings, {
+    mount(Share, {
       target: anchor,
       props: {
         tournamentId:

--- a/app/frontend/pairings/Share.svelte
+++ b/app/frontend/pairings/Share.svelte
@@ -13,7 +13,7 @@
     roundId: number;
   } = $props();
 
-  const MAX_MARKDOWN_PAGE_LENGTH = 2000;
+  const MAX_MARKDOWN_PAGE_LENGTH = 2000;  // Break things up roughly around the Discord message limit.
 
   let betaEnabledCookie: CookieListItem | null = $state(null);
   let data: RoundData | undefined = $state();
@@ -68,7 +68,7 @@
   <h2>Export Pairings as Markdown</h2>
 
   {#each markdownPages as text, i (i)}
-    <div class="mb-3">
+    <div style="margin-bottom: 2rem">
       <SharePage {text} page={i + 1} />
     </div>
   {/each}

--- a/app/frontend/pairings/SharePage.svelte
+++ b/app/frontend/pairings/SharePage.svelte
@@ -18,11 +18,7 @@
   }
 </script>
 
-<h3>Page {page}</h3>
-
-<textarea readonly={true}>{text}</textarea>
-
-<span>
+<h3>
   <ProgressButton
     css="btn btn-info align-top"
     inProgressText="Copying"
@@ -30,7 +26,12 @@
     onclick={copyMarkdown}
   >
     <FontAwesomeIcon icon="copy" /> Copy
-  </ProgressButton>
+  </ProgressButton> <span style="margin-left: 1rem">Page {page}</span>
+</h3>
+
+<textarea readonly={true} style="width: 100%; min-height: 15rem; box-sizing: border-box;">{text}</textarea>
+
+<span>
   {#if error}
     <div class="alert alert-danger">{error}</div>
   {/if}


### PR DESCRIPTION
This uses space a bit better and puts the copy button on the same line as the page number.

Page size temporarily brought down for demo purposes (but left alone for the actual PR).

I want to make this available to players as well (there is no secret data and it is read-only) but there is a bit of refactoring needed first and it may be better off waiting for the JSONAPI to expand a bit more.

<img width="1148" height="1167" alt="Screenshot 2026-05-27 at 10 58 58 PM" src="https://github.com/user-attachments/assets/c9d2be97-b755-45c0-8fca-3a8edfc0e24a" />
