### PR TITLE
Svelte conversion - Add deck editing to registration page

### DIFF
--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -179,7 +179,7 @@ module Beta
 
       details.keep_if { |key| Deck.column_names.include? key }
       details[:side_id] = side
-      details[:user_id] = current_user.id
+      details[:user_id] = @player.user_id
       @player.decks.destroy_by(side_id: side)
       deck = @player.decks.create(details)
       deck.cards.create(params[param][:cards])

--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -137,14 +137,16 @@ module Beta
     end
 
     def decks
-      authorize @tournament, :update?
+      authorize @tournament, :show?
 
       decks = if params[:id]
-                @tournament.players.find(params[:id]&.to_i).decks.sort_by(&:side_id)
+                @tournament.players.find(params[:id]&.to_i).decks
               else
-                @tournament.players.sort_by(&:name).flat_map { |p| p.decks.sort_by(&:side_id) }
+                @tournament.players.sort_by(&:name).flat_map(&:decks)
               end
-      render json: decks.map { |d| d.as_view(current_user) }
+      decks = decks.select { |d| d.user_id == current_user.id } if current_user != @tournament.user
+
+      render json: decks.sort_by(&:side_id).map { |d| d.as_view(current_user) }
     end
 
     private

--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -3,7 +3,8 @@
 module Beta
   class PlayersController < ApplicationController # rubocop:disable Metrics/ClassLength,Style/Documentation
     before_action :set_tournament
-    before_action :set_player, only: %i[update destroy lock_registration unlock_registration drop reinstate]
+    before_action :set_player,
+                  only: %i[update destroy registration lock_registration unlock_registration drop reinstate]
 
     def index
       authorize @tournament, :update?
@@ -87,6 +88,10 @@ module Beta
       render json: helpers.player_json(@tournament.players.find { |p|
         p.user_id == params[:user_id].to_i
       })
+    end
+
+    def registration
+      authorize @tournament, :update?
     end
 
     def lock_registration

--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -4,10 +4,16 @@ module Beta
   class PlayersController < ApplicationController # rubocop:disable Metrics/ClassLength,Style/Documentation
     before_action :set_tournament
     before_action :set_player,
-                  only: %i[update destroy registration lock_registration unlock_registration drop reinstate]
+                  only: %i[show update destroy registration lock_registration unlock_registration drop reinstate]
 
     def index
       authorize @tournament, :update?
+    end
+
+    def show
+      authorize @player, :update?
+
+      render json: @player
     end
 
     def players_data

--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -128,12 +128,12 @@ module Beta
     def decks
       authorize @tournament, :update?
 
-      players = @tournament.players
-      players = players.find(params[:id]&.to_i) if params[:id]
-      render json: players
-                   .sort_by(&:name)
-                   .flat_map { |p| p.decks.sort_by(&:side_id) }
-                   .map { |d| d.as_view(current_user) }
+      decks = if params[:id]
+                @tournament.players.find(params[:id]&.to_i).decks.sort_by(&:side_id)
+              else
+                @tournament.players.sort_by(&:name).flat_map { |p| p.decks.sort_by(&:side_id) }
+              end
+      render json: decks.map { |d| d.as_view(current_user) }
     end
 
     private
@@ -143,9 +143,14 @@ module Beta
     end
 
     def player_params
+      deck_params = { details: %i[name nrdb_uuid mine identity_title identity_nrdb_printing_id
+                                  identity_nrdb_card_id side_id faction_id min_deck_size max_influence],
+                      cards: %i[title quantity influence influence_cost nrdb_card_id nrdb_printing_id faction_id
+                                card_type_id] }
       params.require(:player)
-            .permit(%i[name pronouns corp_identity runner_identity corp_deck runner_deck
-                       first_round_bye manual_seed include_in_stream fixed_table_number])
+            .permit([:name, :pronouns, :corp_identity, :runner_identity, :first_round_bye, :manual_seed,
+                     :include_in_stream, :fixed_table_number,
+                     { corp_deck: deck_params, runner_deck: deck_params }])
     end
 
     def organiser_view?
@@ -155,21 +160,16 @@ module Beta
     def save_deck(params, param, side)
       return unless params.key?(param)
 
-      begin
-        request = JSON.parse(params[param])
-      rescue StandardError
-        @player.decks.destroy_by(side_id: side)
-        return
-      end
-      details = request['details']
-      return if details['user_id'] && details['user_id'] != current_user.id
+      deck = params[param]
+      details = deck[:details]
+      return if details[:user_id] && details[:user_id] != current_user.id
 
       details.keep_if { |key| Deck.column_names.include? key }
-      details['side_id'] = side
-      details['user_id'] = current_user.id
+      details[:side_id] = side
+      details[:user_id] = current_user.id
       @player.decks.destroy_by(side_id: side)
       deck = @player.decks.create(details)
-      deck.cards.create(request['cards'])
+      deck.cards.create(params[param][:cards])
     end
   end
 end

--- a/app/controllers/beta/players_controller.rb
+++ b/app/controllers/beta/players_controller.rb
@@ -128,10 +128,12 @@ module Beta
     def decks
       authorize @tournament, :update?
 
-      render json: @tournament.players
-                              .sort_by(&:name)
-                              .flat_map { |p| p.decks.sort_by(&:side_id) }
-                              .map { |d| d.as_view(current_user) }
+      players = @tournament.players
+      players = players.find(params[:id]&.to_i) if params[:id]
+      render json: players
+                   .sort_by(&:name)
+                   .flat_map { |p| p.decks.sort_by(&:side_id) }
+                   .map { |d| d.as_view(current_user) }
     end
 
     private

--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -91,16 +91,16 @@ module Beta
       players = @tournament.players.includes(%i[corp_identity_ref runner_identity_ref]).active.sort_by do |p|
         p.name || ''
       end
-      current_user_player = players.find do |p|
+      @current_user_player = players.find do |p|
         p.user_id == current_user.id
       end
-      unless current_user_player
+      unless @current_user_player
         redirect_to tournament_path(@tournament)
         return
       end
 
       return unless @tournament.nrdb_deck_registration?
-      return if current_user_player.registration_locked?
+      return if @current_user_player.registration_locked?
 
       begin
         @decks = Nrdb::Connection.new(current_user).decks.map do |deck|

--- a/app/frontend/entrypoints/registration.ts
+++ b/app/frontend/entrypoints/registration.ts
@@ -1,6 +1,6 @@
 import { mount } from "svelte";
 import Registration from "../players/Registration.svelte";
-import { type NrdbDeck } from "../utils/decks";
+import { type NrdbDeck } from "../utils/decks.svelte";
 
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("registration_anchor");

--- a/app/frontend/entrypoints/registration.ts
+++ b/app/frontend/entrypoints/registration.ts
@@ -11,7 +11,7 @@ document.addEventListener("turbolinks:load", function () {
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament-id") ?? "") || -1,
-        userId: Number(anchor.getAttribute("data-user-id") ?? "") || -1,
+        playerId: Number(anchor.getAttribute("data-player-id") ?? "") || -1,
         nrdbDecks: decksString ? (JSON.parse(decksString) as NrdbDeck[]) : [],
       },
     });

--- a/app/frontend/entrypoints/registration.ts
+++ b/app/frontend/entrypoints/registration.ts
@@ -8,12 +8,14 @@ document.addEventListener("turbolinks:load", function () {
     let decks: NrdbDeck[] = [];
     if (anchor.getAttribute("data-user-decks")) {
       try {
-        decks = JSON.parse(anchor.getAttribute("data-user-decks") ?? "") as NrdbDeck[];
+        decks = JSON.parse(
+          anchor.getAttribute("data-user-decks") ?? "",
+        ) as NrdbDeck[];
       } catch {
         decks = [];
       }
     }
-    
+
     mount(Registration, {
       target: anchor,
       props: {

--- a/app/frontend/entrypoints/registration.ts
+++ b/app/frontend/entrypoints/registration.ts
@@ -5,14 +5,22 @@ import { type NrdbDeck } from "../utils/decks.svelte";
 document.addEventListener("turbolinks:load", function () {
   const anchor = document.getElementById("registration_anchor");
   if (anchor?.childNodes.length == 0) {
-    const decksString = anchor.getAttribute("data-user-decks");
+    let decks: NrdbDeck[] = [];
+    if (anchor.getAttribute("data-user-decks")) {
+      try {
+        decks = JSON.parse(anchor.getAttribute("data-user-decks") ?? "") as NrdbDeck[];
+      } catch {
+        decks = [];
+      }
+    }
+    
     mount(Registration, {
       target: anchor,
       props: {
         tournamentId:
           Number(anchor.getAttribute("data-tournament-id") ?? "") || -1,
         playerId: Number(anchor.getAttribute("data-player-id") ?? "") || -1,
-        nrdbDecks: decksString ? (JSON.parse(decksString) as NrdbDeck[]) : [],
+        nrdbDecks: decks,
       },
     });
   }

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -68,7 +68,7 @@
   <tbody>
     <tr>
       <td>
-        {#if deck}
+        {#if deck && deck.details.id !== 0}
           {#if deck.details.name}
             {deck.details.name}
             <div class="float-right dontprint">
@@ -123,7 +123,7 @@
   </tbody>
 </table>
 
-{#if deck}
+{#if deck && deck.details.id !== 0}
   <!-- Identity -->
   <table class="table table-bordered table-striped">
     <thead class="thead-dark">
@@ -139,8 +139,8 @@
         <td>
           <Identity
             identity={{
-              name: deck.details.identity_title,
-              faction: adjustFactionId(deck.details.faction_id),
+              name: deck.details.identity_title ?? "",
+              faction: adjustFactionId(deck.details.faction_id ?? ""),
             }}
           />
         </td>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Identity from "../identities/Identity.svelte";
-  import { deckCsv, type Card, type Deck } from "../utils/decks";
+  import { deckCsv, type Card, type Deck } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -63,16 +63,49 @@
     );
   }
 
-  async function cardNameChanged(event: { currentTarget: HTMLInputElement }, card: Card) {
-    const currentTarget = event.currentTarget;
+  async function searchCard(name: string, cardType?: string) {
+    if (!deck || !name) {
+      return null;
+    }
+    
+    let queryString = `filter[side_id]=${deck.details.side_id}&filter[search]=${name}&filter[distinct_cards]=true&page[size]=1`;
+    if (cardType) {
+      queryString += `filter[card_type_id]=${cardType}`;
+    }
 
-    if (!deck || !currentTarget.value) {
+    const printings = await loadPrintings(queryString);
+    return !printings || (printings.meta?.stats?.total?.count && printings.meta.stats.total.count !== 1)
+      ? null
+      : printings;
+  }
+
+  async function identityNameChanged(event: { currentTarget: HTMLInputElement }) {
+    const currentTarget = event.currentTarget;
+    if (!deck) {
+      setInputValidity(currentTarget, false);
+      return;
+    }
+    
+    const printings = await searchCard(currentTarget.value, `${deck.details.side_id}_identity`);
+    if (!printings) {
       setInputValidity(currentTarget, false);
       return;
     }
 
-    const printings = await loadPrintings(`filter[side_id]=${deck.details.side_id}&filter[search]=${currentTarget.value}&filter[distinct_cards]=true&page[size]=1`);
-    if (!printings || (printings.meta?.stats?.total?.count && printings.meta.stats.total.count !== 1)) {
+    deck.details.identity_nrdb_printing_id = printings.data[0].id;
+    deck.details.identity_nrdb_card_id = printings.data[0].attributes.card_id;
+    deck.details.identity_title = printings.data[0].attributes.title;
+    deck.details.faction_id = printings.data[0].attributes.faction_id;
+    deck.details.min_deck_size = printings.data[0].attributes.minimum_deck_size;
+    deck.details.max_influence = printings.data[0].attributes.influence_limit;
+    setInputValidity(currentTarget, true);
+  }
+
+  async function cardNameChanged(event: { currentTarget: HTMLInputElement }, card: Card) {
+    const currentTarget = event.currentTarget;
+    const printings = await searchCard(currentTarget.value);
+
+    if (!deck || !printings) {
       setInputValidity(currentTarget, false);
       return;
     }
@@ -100,33 +133,46 @@
     setInputValidity(currentTarget, true);
   }
 
-  // function addCard(event: { currentTarget: HTMLInputElement }) {
-  //   console.log(JSON.stringify(event));
+  async function addCard(event: { currentTarget: HTMLInputElement }) {
+    const currentTarget = event.currentTarget;
+    const printings = await searchCard(currentTarget.value);
 
-  //   let valid = false;
-  //   if (event.currentTarget.value) {
-  //     const newCardPrinting = printings.values().find((p) => p.attributes.title.includes(event.currentTarget.value));
-  //     if (newCardPrinting) {
-  //       deck?.cards.push({
-  //         id: "",
-  //         deck_id: deck.details.id,
-  //         title: newCardPrinting.attributes.title,
-  //         quantity: 1,
-  //         influence: newCardPrinting.attributes.influence_cost,
-  //         nrdb_card_id: newCardPrinting.attributes.card_id,
-  //         created_at: "",
-  //         updated_at: "",
-  //         nrdb_printing_id: newCardPrinting.id,
-  //         card_type_id: newCardPrinting.attributes.card_type_id,
-  //         faction_id: newCardPrinting.attributes.faction_id,
-  //         influence_cost: newCardPrinting.attributes.influence_cost,
-  //       });
-  //       valid = true;
-  //     }
-  //   }
+    if (!deck || !printings) {
+      setInputValidity(currentTarget, false);
+      return;
+    }
 
-  //   setInputValidity(event.currentTarget, valid);
-  // }
+    deck.cards.push({
+      id: "",
+      deck_id: deck.details.id,
+      title: printings.data[0].attributes.title,
+      quantity: 1,
+      influence: printings.data[0].attributes.influence_cost,
+      nrdb_card_id: printings.data[0].attributes.card_id,
+      created_at: "",
+      updated_at: "",
+      nrdb_printing_id: printings.data[0].id,
+      card_type_id: printings.data[0].attributes.card_type_id,
+      faction_id: printings.data[0].attributes.faction_id,
+      influence_cost: printings.data[0].attributes.influence_cost,
+    });
+    currentTarget.classList.remove("is-valid", "is-invalid");
+    currentTarget.value = "";
+  }
+
+  function changeQuantity(card: Card, delta: number) {
+    if (!deck) {
+      return;
+    }
+
+    card.quantity += delta;
+    if (card.quantity === 0) {
+      const i = deck.cards.indexOf(card);
+      if (i !== -1) {
+        deck.cards.splice(i, 1);
+      }
+    }
+  }
 
   function setInputValidity(input: HTMLInputElement, valid: boolean) {
     input.classList.remove("is-valid", "is-invalid");
@@ -221,14 +267,13 @@
         <td class="text-center align-middle">{deck.details.min_deck_size}</td>
         <td>
           {#if editMode}
-            <!-- TODO: Autocomplete -->
             <input
               id="name"
               type="text"
               placeholder="Enter identity name"
               class="form-control"
               value={deck.details.identity_title}
-              onchange={() => { /* TODO: Function to update deck.details */ }}
+              onchange={async (e) => { await identityNameChanged(e); }}
             />
           {:else}
             <Identity
@@ -257,7 +302,19 @@
       <!-- Cards -->
       {#each deck.cards as card (card.id)}
         <tr>
-          <td class="text-center align-middle">{card.quantity}</td>
+          <td class="text-center align-middle">
+            {#if editMode}
+              <button type="button" title="Remove" class="btn btn-link p-0" onclick={() => { changeQuantity(card, -1); }}>
+                <FontAwesomeIcon icon="minus" />
+              </button>
+            {/if}
+            {card.quantity}
+            {#if editMode}
+              <button type="button" title="Add" class="btn btn-link p-0" onclick={() => { changeQuantity(card, 1); }}>
+                <FontAwesomeIcon icon="plus" />
+              </button>
+            {/if}
+          </td>
           <td>
             {#if editMode}
               <input
@@ -297,8 +354,8 @@
               type="text"
               placeholder="Enter card name"
               class="form-control"
-              />
-              <!-- onchange={(e) => { addCard(e); }} -->
+              onchange={async (e) => { await addCard(e); }}
+            />
           </td>
           <td></td>
         </tr>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import Identity from "../identities/Identity.svelte";
-  import { deckCsv, type Card, type Deck, loadPrintings } from "../utils/decks.svelte";
+  import {
+    deckCsv,
+    type Card,
+    type Deck,
+    loadPrintings,
+  } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
@@ -67,26 +72,33 @@
     if (!deck || !name) {
       return null;
     }
-    
+
     let queryString = `filter[side_id]=${deck.details.side_id}&filter[search]=${name}&filter[distinct_cards]=true&page[size]=1`;
     if (cardType) {
       queryString += `filter[card_type_id]=${cardType}`;
     }
 
     const printings = await loadPrintings(queryString);
-    return !printings || (printings.meta?.stats?.total?.count && printings.meta.stats.total.count !== 1)
+    return !printings ||
+      (printings.meta?.stats?.total?.count &&
+        printings.meta.stats.total.count !== 1)
       ? null
       : printings;
   }
 
-  async function identityNameChanged(event: { currentTarget: HTMLInputElement }) {
+  async function identityNameChanged(event: {
+    currentTarget: HTMLInputElement;
+  }) {
     const currentTarget = event.currentTarget;
     if (!deck) {
       setInputValidity(currentTarget, false);
       return;
     }
-    
-    const printings = await searchCard(currentTarget.value, `${deck.details.side_id}_identity`);
+
+    const printings = await searchCard(
+      currentTarget.value,
+      `${deck.details.side_id}_identity`,
+    );
     if (!printings) {
       setInputValidity(currentTarget, false);
       return;
@@ -101,7 +113,10 @@
     setInputValidity(currentTarget, true);
   }
 
-  async function cardNameChanged(event: { currentTarget: HTMLInputElement }, card: Card) {
+  async function cardNameChanged(
+    event: { currentTarget: HTMLInputElement },
+    card: Card,
+  ) {
     const currentTarget = event.currentTarget;
     const printings = await searchCard(currentTarget.value);
 
@@ -176,7 +191,7 @@
 
   function setInputValidity(input: HTMLInputElement, valid: boolean) {
     input.classList.remove("is-valid", "is-invalid");
-    
+
     if (valid) {
       input.classList.add("is-valid");
     } else {
@@ -273,7 +288,9 @@
               placeholder="Enter identity name"
               class="form-control"
               value={deck.details.identity_title}
-              onchange={async (e) => { await identityNameChanged(e); }}
+              onchange={async (e) => {
+                await identityNameChanged(e);
+              }}
             />
           {:else}
             <Identity
@@ -304,13 +321,27 @@
         <tr>
           <td class="text-center align-middle">
             {#if editMode}
-              <button type="button" title="Remove" class="btn btn-link p-0" onclick={() => { changeQuantity(card, -1); }}>
+              <button
+                type="button"
+                title="Remove"
+                class="btn btn-link p-0"
+                onclick={() => {
+                  changeQuantity(card, -1);
+                }}
+              >
                 <FontAwesomeIcon icon="minus" />
               </button>
             {/if}
             {card.quantity}
             {#if editMode}
-              <button type="button" title="Add" class="btn btn-link p-0" onclick={() => { changeQuantity(card, 1); }}>
+              <button
+                type="button"
+                title="Add"
+                class="btn btn-link p-0"
+                onclick={() => {
+                  changeQuantity(card, 1);
+                }}
+              >
                 <FontAwesomeIcon icon="plus" />
               </button>
             {/if}
@@ -323,7 +354,9 @@
                 placeholder="Enter card name"
                 class="form-control"
                 value={card.title}
-                onchange={async (e) => { await cardNameChanged(e, card); }}
+                onchange={async (e) => {
+                  await cardNameChanged(e, card);
+                }}
               />
             {:else}
               <img
@@ -354,7 +387,9 @@
               type="text"
               placeholder="Enter card name"
               class="form-control"
-              onchange={async (e) => { await addCard(e); }}
+              onchange={async (e) => {
+                await addCard(e);
+              }}
             />
           </td>
           <td></td>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import Identity from "../identities/Identity.svelte";
-  import { deckCsv, type Card, type Deck } from "../utils/decks.svelte";
+  import { deckCsv, type Card, type Deck, loadPrintings } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
 
-  let { deck, isCorp }: { deck: Deck | null; isCorp: boolean } = $props();
+  let {
+    deck = $bindable(),
+    isCorp,
+    editMode,
+  }: {
+    deck?: Deck;
+    isCorp: boolean;
+    editMode: boolean;
+  } = $props();
 
   let cardTotal = $derived.by(() => {
     if (!deck) {
@@ -53,6 +61,81 @@
       `${deck.details.player_name} - ${deck.details.name}.csv`,
       new Blob([deckCsv([deck])], { type: "text/csv" }),
     );
+  }
+
+  async function cardNameChanged(event: { currentTarget: HTMLInputElement }, card: Card) {
+    const currentTarget = event.currentTarget;
+
+    if (!deck || !currentTarget.value) {
+      setInputValidity(currentTarget, false);
+      return;
+    }
+
+    const printings = await loadPrintings(`filter[side_id]=${deck.details.side_id}&filter[search]=${currentTarget.value}&filter[distinct_cards]=true&page[size]=1`);
+    if (!printings || (printings.meta?.stats?.total?.count && printings.meta.stats.total.count !== 1)) {
+      setInputValidity(currentTarget, false);
+      return;
+    }
+
+    const i = deck.cards.indexOf(card);
+    if (i === -1) {
+      setInputValidity(currentTarget, false);
+      return;
+    }
+
+    deck.cards.splice(i, 1, {
+      id: card.id,
+      deck_id: card.deck_id,
+      title: printings.data[0].attributes.title,
+      quantity: card.quantity,
+      influence: printings.data[0].attributes.influence_cost * card.quantity,
+      nrdb_card_id: printings.data[0].attributes.card_id,
+      created_at: "",
+      updated_at: "",
+      nrdb_printing_id: card.id,
+      card_type_id: printings.data[0].attributes.card_type_id,
+      faction_id: printings.data[0].attributes.faction_id,
+      influence_cost: printings.data[0].attributes.influence_cost,
+    });
+    setInputValidity(currentTarget, true);
+  }
+
+  // function addCard(event: { currentTarget: HTMLInputElement }) {
+  //   console.log(JSON.stringify(event));
+
+  //   let valid = false;
+  //   if (event.currentTarget.value) {
+  //     const newCardPrinting = printings.values().find((p) => p.attributes.title.includes(event.currentTarget.value));
+  //     if (newCardPrinting) {
+  //       deck?.cards.push({
+  //         id: "",
+  //         deck_id: deck.details.id,
+  //         title: newCardPrinting.attributes.title,
+  //         quantity: 1,
+  //         influence: newCardPrinting.attributes.influence_cost,
+  //         nrdb_card_id: newCardPrinting.attributes.card_id,
+  //         created_at: "",
+  //         updated_at: "",
+  //         nrdb_printing_id: newCardPrinting.id,
+  //         card_type_id: newCardPrinting.attributes.card_type_id,
+  //         faction_id: newCardPrinting.attributes.faction_id,
+  //         influence_cost: newCardPrinting.attributes.influence_cost,
+  //       });
+  //       valid = true;
+  //     }
+  //   }
+
+  //   setInputValidity(event.currentTarget, valid);
+  // }
+
+  function setInputValidity(input: HTMLInputElement, valid: boolean) {
+    input.classList.remove("is-valid", "is-invalid");
+    
+    if (valid) {
+      input.classList.add("is-valid");
+    } else {
+      input.classList.add("is-invalid");
+    }
   }
 </script>
 
@@ -137,12 +220,24 @@
       <tr>
         <td class="text-center align-middle">{deck.details.min_deck_size}</td>
         <td>
-          <Identity
-            identity={{
-              name: deck.details.identity_title ?? "",
-              faction: adjustFactionId(deck.details.faction_id ?? ""),
-            }}
-          />
+          {#if editMode}
+            <!-- TODO: Autocomplete -->
+            <input
+              id="name"
+              type="text"
+              placeholder="Enter identity name"
+              class="form-control"
+              value={deck.details.identity_title}
+              onchange={() => { /* TODO: Function to update deck.details */ }}
+            />
+          {:else}
+            <Identity
+              identity={{
+                name: deck.details.identity_title ?? "",
+                faction: adjustFactionId(deck.details.faction_id ?? ""),
+              }}
+            />
+          {/if}
         </td>
         <td class="text-center align-middle">{deck.details.max_influence}</td>
       </tr>
@@ -164,16 +259,27 @@
         <tr>
           <td class="text-center align-middle">{card.quantity}</td>
           <td>
-            <img
-              src={getCardTypeImage(card.card_type_id)}
-              alt={card.card_type_id}
-            />
-            <i
-              class="fa icon icon-{adjustFactionId(
-                card.faction_id,
-              )} {adjustFactionId(card.faction_id)}"
-            ></i>
-            {card.title}
+            {#if editMode}
+              <input
+                id="name"
+                type="text"
+                placeholder="Enter card name"
+                class="form-control"
+                value={card.title}
+                onchange={async (e) => { await cardNameChanged(e, card); }}
+              />
+            {:else}
+              <img
+                src={getCardTypeImage(card.card_type_id)}
+                alt={card.card_type_id}
+              />
+              <i
+                class="fa icon icon-{adjustFactionId(
+                  card.faction_id,
+                )} {adjustFactionId(card.faction_id)}"
+              ></i>
+              {card.title}
+            {/if}
           </td>
           <td class="text-center align-middle">
             {#if card.influence_cost && card.faction_id != deck.details.faction_id}
@@ -182,6 +288,21 @@
           </td>
         </tr>
       {/each}
+      {#if editMode}
+        <tr>
+          <td></td>
+          <td>
+            <input
+              id="name"
+              type="text"
+              placeholder="Enter card name"
+              class="form-control"
+              />
+              <!-- onchange={(e) => { addCard(e); }} -->
+          </td>
+          <td></td>
+        </tr>
+      {/if}
 
       <!-- Totals -->
       <tr>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -25,7 +25,7 @@
     if (deck) {
       sortCards(deck.cards);
     }
-  })
+  });
 
   let cardTotal = $derived.by(() => {
     if (!deck) {
@@ -97,6 +97,7 @@
     currentTarget: HTMLInputElement;
   }) {
     const currentTarget = event.currentTarget;
+
     if (!deck) {
       setInputValidity(currentTarget, false);
       return;
@@ -126,7 +127,6 @@
   ) {
     const currentTarget = event.currentTarget;
     const printings = await searchCard(currentTarget.value);
-
     if (!deck || !printings) {
       setInputValidity(currentTarget, false);
       return;
@@ -158,7 +158,6 @@
   async function addCard(event: { currentTarget: HTMLInputElement }) {
     const currentTarget = event.currentTarget;
     const printings = await searchCard(currentTarget.value);
-
     if (!deck || !printings) {
       setInputValidity(currentTarget, false);
       return;
@@ -198,12 +197,7 @@
 
   function setInputValidity(input: HTMLInputElement, valid: boolean) {
     input.classList.remove("is-valid", "is-invalid");
-
-    if (valid) {
-      input.classList.add("is-valid");
-    } else {
-      input.classList.add("is-invalid");
-    }
+    input.classList.add(valid ? "is-valid" : "is-invalid");
   }
 </script>
 

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -5,6 +5,7 @@
     type Card,
     type Deck,
     loadPrintings,
+    sortCards,
   } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
@@ -19,6 +20,12 @@
     isCorp: boolean;
     editMode: boolean;
   } = $props();
+
+  $effect(() => {
+    if (deck) {
+      sortCards(deck.cards);
+    }
+  })
 
   let cardTotal = $derived.by(() => {
     if (!deck) {

--- a/app/frontend/players/PlayerForm.svelte
+++ b/app/frontend/players/PlayerForm.svelte
@@ -247,7 +247,7 @@
   <!-- View decks -->
   {#if tournament.nrdb_deck_registration && playerEdit.id !== 0}
     <a
-      href={`/tournaments/${tournament.id}/players/${playerEdit.id}/registration`}
+      href={`/beta/tournaments/${tournament.id}/players/${playerEdit.id}/registration?edit=true`}
       class="btn btn-link text-info"
     >
       <FontAwesomeIcon icon="eye" />

--- a/app/frontend/players/Players.svelte
+++ b/app/frontend/players/Players.svelte
@@ -25,7 +25,7 @@
     loadIdentityNames,
     type IdentityNames,
   } from "../identities/Identity";
-  import { deckCsv } from "../utils/decks";
+  import { deckCsv } from "../utils/decks.svelte";
 
   let { tournamentId }: { tournamentId: number } = $props();
 

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -1,7 +1,7 @@
 import { Identity } from "../identities/Identity";
 import type { TournamentPolicies } from "../pairings/PairingsData";
 import type { Tournament } from "../tournaments/TournamentSettings";
-import type { Deck } from "../utils/decks";
+import type { Card, Deck } from "../utils/decks";
 import { globalMessages } from "../utils/GlobalMessageState.svelte";
 import { csrfToken } from "../utils/network";
 
@@ -28,7 +28,6 @@ declare const Routes: {
     tournamentId: number,
     playerId: number,
   ) => string;
-  decks_beta_tournament_players_path: (tournamentId: number, playerId: number | null) => string;
 };
 
 export async function loadPlayers(tournamentId: number) {
@@ -149,7 +148,9 @@ export async function reinstatePlayer(tournamentId: number, player: Player) {
 
 export async function loadDecks(tournamentId: number, playerId: number | null = null) {
   const response = await fetch(
-    Routes.decks_beta_tournament_players_path(tournamentId, playerId),
+    playerId === null
+      ? `/beta/tournaments/${tournamentId}/players/decks`
+      : `/beta/tournaments/${tournamentId}/players/${playerId}/decks`,
     {
       method: "GET",
     },
@@ -168,7 +169,38 @@ function playerRequestObject(player: Player) {
     first_round_bye: player.first_round_bye,
     manual_seed: player.manual_seed,
     fixed_table_number: player.fixed_table_number,
+    corp_deck: player.corp_deck ? deckRequestObject(player.corp_deck) : undefined,
+    runner_deck: player.runner_deck ? deckRequestObject(player.runner_deck) : undefined,
   };
+}
+
+function deckRequestObject(deck: Deck) {
+  const {
+    id,
+    user_id,
+    player_id,
+    player_name,
+    created_at,
+    updated_at,
+    ...details
+  } = deck.details;
+
+  return {
+    details: details,
+    cards: deck.cards.map((c) => cardRequestObject(c)),
+  };
+}
+
+function cardRequestObject(card: Card) {
+  const {
+    id,
+    deck_id,
+    created_at,
+    updated_at,
+    ...newCard
+  } = card;
+
+  return newCard;
 }
 
 export interface PlayersData {
@@ -194,4 +226,6 @@ export class Player {
   fixed_table_number: number | null = null;
   side: string | null = null;
   side_label: string | null = null;
+  corp_deck?: Deck;
+  runner_deck?: Deck;
 }

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -1,7 +1,7 @@
 import { Identity } from "../identities/Identity";
 import type { TournamentPolicies } from "../pairings/PairingsData";
 import type { Tournament } from "../tournaments/TournamentSettings";
-import type { Card, Deck } from "../utils/decks";
+import type { Card, Deck } from "../utils/decks.svelte";
 import { globalMessages } from "../utils/GlobalMessageState.svelte";
 import { csrfToken } from "../utils/network";
 

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -42,7 +42,7 @@ export async function loadPlayer(tournamentId: number, playerId: number) {
     return (await response.json()) as Player;
   } catch {
     globalMessages.errors.push(
-      `Error loading player data for player ${playerId}`,
+      `Error loading player data for player ${playerId}.`,
     );
     return null;
   }
@@ -180,12 +180,9 @@ export async function reinstatePlayer(tournamentId: number, player: Player) {
   return response.status === 200;
 }
 
-export async function loadDecks(
-  tournamentId: number,
-  playerId: number | null = null,
-) {
+export async function loadDecks(tournamentId: number, playerId?: number) {
   const response = await fetch(
-    playerId === null
+    playerId === undefined
       ? `/beta/tournaments/${tournamentId}/players/decks`
       : `/beta/tournaments/${tournamentId}/players/${playerId}/decks`,
     {

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -39,9 +39,11 @@ export async function loadPlayer(tournamentId: number, playerId: number) {
       },
     );
 
-    return  (await response.json()) as Player;
+    return (await response.json()) as Player;
   } catch {
-    globalMessages.errors.push(`Error loading player data for player ${playerId}`);
+    globalMessages.errors.push(
+      `Error loading player data for player ${playerId}`,
+    );
     return null;
   }
 }

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -146,7 +146,10 @@ export async function reinstatePlayer(tournamentId: number, player: Player) {
   return response.status === 200;
 }
 
-export async function loadDecks(tournamentId: number, playerId: number | null = null) {
+export async function loadDecks(
+  tournamentId: number,
+  playerId: number | null = null,
+) {
   const response = await fetch(
     playerId === null
       ? `/beta/tournaments/${tournamentId}/players/decks`
@@ -169,8 +172,12 @@ function playerRequestObject(player: Player) {
     first_round_bye: player.first_round_bye,
     manual_seed: player.manual_seed,
     fixed_table_number: player.fixed_table_number,
-    corp_deck: player.corp_deck ? deckRequestObject(player.corp_deck) : undefined,
-    runner_deck: player.runner_deck ? deckRequestObject(player.runner_deck) : undefined,
+    corp_deck: player.corp_deck
+      ? deckRequestObject(player.corp_deck)
+      : undefined,
+    runner_deck: player.runner_deck
+      ? deckRequestObject(player.runner_deck)
+      : undefined,
   };
 }
 
@@ -192,13 +199,7 @@ function deckRequestObject(deck: Deck) {
 }
 
 function cardRequestObject(card: Card) {
-  const {
-    id,
-    deck_id,
-    created_at,
-    updated_at,
-    ...newCard
-  } = card;
+  const { id, deck_id, created_at, updated_at, ...newCard } = card;
 
   return newCard;
 }

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -30,6 +30,38 @@ declare const Routes: {
   ) => string;
 };
 
+export async function loadPlayer(tournamentId: number, playerId: number) {
+  try {
+    const response = await fetch(
+      `/beta/tournaments/${tournamentId}/players/${playerId}`,
+      {
+        method: "GET",
+      },
+    );
+
+    return  (await response.json()) as Player;
+  } catch {
+    globalMessages.errors.push(`Error loading player data for player ${playerId}`);
+    return null;
+  }
+}
+
+export async function loadPlayerByUserId(tournamentId: number, userId: number) {
+  try {
+    const response = await fetch(
+      `/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
+      {
+        method: "GET",
+      },
+    );
+
+    return (await response.json()) as Player;
+  } catch {
+    globalMessages.errors.push(`Error loading player data for user ${userId}.`);
+    return null;
+  }
+}
+
 export async function loadPlayers(tournamentId: number) {
   const response = await fetch(
     Routes.players_data_beta_tournament_players_path(tournamentId),

--- a/app/frontend/players/PlayersData.ts
+++ b/app/frontend/players/PlayersData.ts
@@ -28,7 +28,7 @@ declare const Routes: {
     tournamentId: number,
     playerId: number,
   ) => string;
-  decks_beta_tournament_players_path: (tournamentId: number) => string;
+  decks_beta_tournament_players_path: (tournamentId: number, playerId: number | null) => string;
 };
 
 export async function loadPlayers(tournamentId: number) {
@@ -147,9 +147,9 @@ export async function reinstatePlayer(tournamentId: number, player: Player) {
   return response.status === 200;
 }
 
-export async function loadDecks(tournamentId: number) {
+export async function loadDecks(tournamentId: number, playerId: number | null = null) {
   const response = await fetch(
-    Routes.decks_beta_tournament_players_path(tournamentId),
+    Routes.decks_beta_tournament_players_path(tournamentId, playerId),
     {
       method: "GET",
     },

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -14,10 +14,7 @@
     convertNrdbDeck,
     getPrintings,
   } from "../utils/decks.svelte";
-  import {
-    loadDecks,
-    savePlayer,
-  } from "../players/PlayersData";
+  import { loadDecks, savePlayer } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
 
   let {
@@ -101,7 +98,11 @@
       name: runnerDeck.details.identity_title ?? "",
       faction: runnerDeck.details.faction_id,
     };
-    player = await savePlayer(tournamentId, player, tournament && player.user_id !== tournament.user_id);
+    player = await savePlayer(
+      tournamentId,
+      player,
+      tournament && player.user_id !== tournament.user_id,
+    );
 
     await loadTournamentDecks();
     toggleEditing();

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -15,7 +15,7 @@
     type Deck,
     convertNrdbDeck,
   } from "../utils/decks";
-  import { savePlayer } from "../players/PlayersData";
+  import { loadDecks, savePlayer } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
   import type { Printing } from "../lib/api_types";
 
@@ -35,6 +35,7 @@
   let tournament = $state<Tournament | undefined>();
   let player = $state(new Player());
   let decks = $state<Deck[]>([]);
+  let tournamentDecks = $state<Deck[]>();
   let printings = $state(new Map<string, Printing>());
   let selectedCorpDeck = $state<Deck | null>(null);
   let selectedRunnerDeck = $state<Deck | null>(null);
@@ -67,6 +68,9 @@
       loadTournament(tournamentId),
       loadPlayer(tournamentId, userId),
     ]);
+    tournamentDecks = await loadDecks(tournamentId, player.id);
+    selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
+    selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
   });
 
   async function save() {

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -12,7 +12,7 @@
   import {
     type NrdbDeck,
     loadPrintings,
-    type Deck,
+    Deck,
     convertNrdbDeck,
   } from "../utils/decks";
   import { loadDecks, savePlayer } from "../players/PlayersData";
@@ -21,11 +21,11 @@
 
   let {
     tournamentId,
-    userId,
+    playerId,
     nrdbDecks,
   }: {
     tournamentId: number;
-    userId: number;
+    playerId: number;
     nrdbDecks: NrdbDeck[];
   } = $props();
 
@@ -44,7 +44,7 @@
   onMount(async () => {
     [tournament, player] = await Promise.all([
       loadTournament(tournamentId),
-      loadPlayer(tournamentId, userId),
+      loadPlayer(tournamentId, playerId),
     ]);
 
     // Load printings and hydrate decks
@@ -75,8 +75,8 @@
 
     if (player) {
       tournamentDecks = await loadDecks(tournamentId, player.id);
-      selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
-      selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
+      selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? new Deck();
+      selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? new Deck();
     }
     decks = loadedDecks;
   });

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -15,7 +15,10 @@
     convertNrdbDeck,
     getPrintings,
   } from "../utils/decks.svelte";
-  import { loadDecks as loadDecksRequest, savePlayer } from "../players/PlayersData";
+  import {
+    loadDecks as loadDecksRequest,
+    savePlayer,
+  } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
 
   let {
@@ -39,7 +42,9 @@
   let corpDeck = $state(new Deck());
   let originalRunnerDeck = $state(new Deck());
   let runnerDeck = $state(new Deck());
-  let editMode = $state(new URLSearchParams(document.location.search).get("edit") === "true");
+  let editMode = $state(
+    new URLSearchParams(document.location.search).get("edit") === "true",
+  );
   let editing = $state(false);
 
   onMount(async () => {
@@ -72,7 +77,7 @@
       }
     }
 
-    loadDecks();
+    await loadDecks();
 
     decks = loadedDecks;
   });
@@ -83,8 +88,10 @@
     }
 
     tournamentDecks = await loadDecksRequest(tournamentId, player.id);
-    originalCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? new Deck();
-    originalRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? new Deck();
+    originalCorpDeck =
+      tournamentDecks.find((d) => d.details.side_id === "corp") ?? new Deck();
+    originalRunnerDeck =
+      tournamentDecks.find((d) => d.details.side_id === "runner") ?? new Deck();
     resetEditDecks();
   }
 
@@ -104,12 +111,18 @@
     }
 
     player.corp_deck = corpDeck;
-    player.corp_id = { name: corpDeck.details.identity_title ?? "", faction: corpDeck.details.faction_id };
+    player.corp_id = {
+      name: corpDeck.details.identity_title ?? "",
+      faction: corpDeck.details.faction_id,
+    };
     player.runner_deck = runnerDeck;
-    player.runner_id = { name: runnerDeck.details.identity_title ?? "", faction: runnerDeck.details.faction_id };
+    player.runner_id = {
+      name: runnerDeck.details.identity_title ?? "",
+      faction: runnerDeck.details.faction_id,
+    };
     player = await savePlayer(tournamentId, player);
-    
-    loadDecks();
+
+    await loadDecks();
 
     return true;
   }
@@ -117,12 +130,12 @@
   function selectDeck(deck: Deck, isCorp: boolean) {
     if (isCorp) {
       originalCorpDeck =
-        deck && deck.details.nrdb_uuid === originalCorpDeck.details.nrdb_uuid
+        deck.details.nrdb_uuid === originalCorpDeck.details.nrdb_uuid
           ? new Deck()
           : deck;
     } else {
       originalRunnerDeck =
-        deck && deck.details.nrdb_uuid === originalRunnerDeck.details.nrdb_uuid
+        deck.details.nrdb_uuid === originalRunnerDeck.details.nrdb_uuid
           ? new Deck()
           : deck;
     }
@@ -182,7 +195,9 @@
             class="selected-deck-identity"
             style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${isCorp ? THE_SYNDICATE_NRDB_CODE : THE_CATALYST_NRDB_CODE}.jpg)`}
           ></div>
-          <p class="mb-1">{isCorp ? "No corp selected" : "No runner selected"}</p>
+          <p class="mb-1">
+            {isCorp ? "No corp selected" : "No runner selected"}
+          </p>
         {/if}
       </li>
     </ul>
@@ -196,17 +211,26 @@
 {/snippet}
 
 {#if player && player.id !== 0 && tournament}
+  <!-- General registration information -->
   <div class="card mb-3">
     <div class="card-header">
       <div class="d-flex justify-content-between">
         <h5 class="mb-0">My Registration Information</h5>
         <span class="float-right dontprint">
-          <button type="button" class="btn btn-link p-0 mr-3" title="Print" onclick={() => { window.print(); }}>
+          <button
+            type="button"
+            class="btn btn-link p-0 mr-3"
+            title="Print"
+            onclick={() => {
+              window.print();
+            }}
+          >
             <FontAwesomeIcon icon="print" />
           </button>
-          <a href={editMode
-            ? `/beta/tournaments/${tournamentId}/rounds`
-            : `/beta/tournaments/${tournamentId}`}
+          <a
+            href={editMode
+              ? `/beta/tournaments/${tournamentId}/rounds`
+              : `/beta/tournaments/${tournamentId}`}
             class="btn btn-link p-0"
             title="Cancel"
           >
@@ -264,16 +288,27 @@
         {#if editMode}
           <div class="float-left">
             {#if editing}
-              <button type="button" class="btn btn-link" onclick={toggleEditing}>
+              <button
+                type="button"
+                class="btn btn-link"
+                onclick={toggleEditing}
+              >
                 <FontAwesomeIcon icon="undo" />
                 Cancel edits
               </button>
             {:else}
-              <a href="/beta/tournaments/{tournamentId}/registration" class="btn btn-link">
+              <a
+                href="/beta/tournaments/{tournamentId}/registration"
+                class="btn btn-link"
+              >
                 <FontAwesomeIcon icon="edit" />
                 Choose decks from your NetrunnerDB account
               </a>
-              <button type="button" class="btn btn-link" onclick={toggleEditing}>
+              <button
+                type="button"
+                class="btn btn-link"
+                onclick={toggleEditing}
+              >
                 <FontAwesomeIcon icon="edit" />
                 Edit decks in place
               </button>
@@ -301,6 +336,7 @@
     Please ensure your decks are legal.
   </div>
 
+  <!-- Deck selection -->
   {#if !editMode}
     <div class="alert alert-secondary dontprint">
       Please select from your decks below. <a
@@ -311,7 +347,6 @@
 
     <div class="row mb-3 justify-content-center dontprint">
       {#if decks !== null}
-        <!-- Corp deck selection -->
         <div class="col-md-6">
           <div class="card">
             <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
@@ -319,7 +354,6 @@
           </div>
         </div>
 
-        <!-- Runner deck selection -->
         <div class="col-md-6">
           <div class="card">
             <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
@@ -332,21 +366,16 @@
     </div>
   {/if}
 
-  {#if corpDeck && runnerDeck}
-    <div class="row">
-      <div class="col-md-6">
-        <DeckDisplay bind:deck={corpDeck} isCorp={true} editMode={editing} />
-      </div>
+  <!-- Deck display -->
+  <div class="row">
+    <div class="col-md-6">
+      <DeckDisplay bind:deck={corpDeck} isCorp={true} editMode={editing} />
+    </div>
 
-      <div class="col-md-6">
-        <DeckDisplay bind:deck={runnerDeck} isCorp={false} editMode={editing} />
-      </div>
+    <div class="col-md-6">
+      <DeckDisplay bind:deck={runnerDeck} isCorp={false} editMode={editing} />
     </div>
-  {:else}
-    <div class="d-flex align-items-center m-2">
-      <div class="spinner-border m-auto"></div>
-    </div>
-  {/if}
+  </div>
 {:else}
   <div class="d-flex align-items-center m-2">
     <div class="spinner-border m-auto"></div>

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -15,7 +15,7 @@
     convertNrdbDeck,
     getPrintings,
   } from "../utils/decks.svelte";
-  import { loadDecks, savePlayer } from "../players/PlayersData";
+  import { loadDecks as loadDecksRequest, savePlayer } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
 
   let {
@@ -35,8 +35,10 @@
   let player = $state<Player | null>(null);
   let decks = $state<Deck[] | null>(null);
   let tournamentDecks = $state<Deck[]>();
-  let selectedCorpDeck = $state(new Deck());
-  let selectedRunnerDeck = $state(new Deck());
+  let originalCorpDeck = $state(new Deck());
+  let corpDeck = $state(new Deck());
+  let originalRunnerDeck = $state(new Deck());
+  let runnerDeck = $state(new Deck());
   let editMode = $state(new URLSearchParams(document.location.search).get("edit") === "true");
   let editing = $state(false);
 
@@ -70,44 +72,61 @@
       }
     }
 
-    if (player) {
-      tournamentDecks = await loadDecks(tournamentId, player.id);
-      selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? new Deck();
-      selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? new Deck();
-    }
+    loadDecks();
+
     decks = loadedDecks;
   });
 
-  function toggleEditing() {
-    // TODO: Update edit mode for DeckDisplay components
-    editing = !editing;
+  async function loadDecks() {
+    if (!player) {
+      return;
+    }
 
-    // TODO: Do the following:
-    // - Create edit copies of selected decks
-    // - Reset edit copies if edit mode is cancelled
+    tournamentDecks = await loadDecksRequest(tournamentId, player.id);
+    originalCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? new Deck();
+    originalRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? new Deck();
+    resetEditDecks();
+  }
+
+  function toggleEditing() {
+    editing = !editing;
+    resetEditDecks();
+  }
+
+  function resetEditDecks() {
+    corpDeck = $state.snapshot(originalCorpDeck);
+    runnerDeck = $state.snapshot(originalRunnerDeck);
   }
 
   async function save() {
-    if (player) {
-      player.corp_deck = selectedCorpDeck ?? undefined;
-      player.runner_deck = selectedRunnerDeck ?? undefined;
-      player = await savePlayer(tournamentId, player);
+    if (!player) {
+      return true;
     }
+
+    player.corp_deck = corpDeck;
+    player.corp_id = { name: corpDeck.details.identity_title ?? "", faction: corpDeck.details.faction_id };
+    player.runner_deck = runnerDeck;
+    player.runner_id = { name: runnerDeck.details.identity_title ?? "", faction: runnerDeck.details.faction_id };
+    player = await savePlayer(tournamentId, player);
+    
+    loadDecks();
+
     return true;
   }
 
   function selectDeck(deck: Deck, isCorp: boolean) {
     if (isCorp) {
-      selectedCorpDeck =
-        deck && deck.details.nrdb_uuid === selectedCorpDeck?.details.nrdb_uuid
+      originalCorpDeck =
+        deck && deck.details.nrdb_uuid === originalCorpDeck.details.nrdb_uuid
           ? new Deck()
           : deck;
     } else {
-      selectedRunnerDeck =
-        deck && deck.details.nrdb_uuid === selectedRunnerDeck?.details.nrdb_uuid
+      originalRunnerDeck =
+        deck && deck.details.nrdb_uuid === originalRunnerDeck.details.nrdb_uuid
           ? new Deck()
           : deck;
     }
+    resetEditDecks();
   }
 </script>
 
@@ -117,8 +136,8 @@
   <button
     class="list-group-item list-group-item-action {deck.details.nrdb_uuid ===
     (isCorp
-      ? selectedCorpDeck?.details.nrdb_uuid
-      : selectedRunnerDeck?.details.nrdb_uuid)
+      ? originalCorpDeck.details.nrdb_uuid
+      : originalRunnerDeck.details.nrdb_uuid)
       ? 'active'
       : ''}"
     onclick={() => {
@@ -139,7 +158,6 @@
     <ul class="list-group list-group-flush" style="border-bottom: 0;">
       <li class="list-group-item selected-deck">
         <div class="selected-deck-buttons">
-          <!-- TODO: Undo -->
           {#if selectedDeck}
             <button
               type="button"
@@ -297,7 +315,7 @@
         <div class="col-md-6">
           <div class="card">
             <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-            {@render decksList(true, selectedCorpDeck)}
+            {@render decksList(true, corpDeck)}
           </div>
         </div>
 
@@ -305,7 +323,7 @@
         <div class="col-md-6">
           <div class="card">
             <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-            {@render decksList(false, selectedRunnerDeck)}
+            {@render decksList(false, runnerDeck)}
           </div>
         </div>
       {:else}
@@ -314,14 +332,14 @@
     </div>
   {/if}
 
-  {#if selectedCorpDeck && selectedRunnerDeck}
+  {#if corpDeck && runnerDeck}
     <div class="row">
       <div class="col-md-6">
-        <DeckDisplay bind:deck={selectedCorpDeck} isCorp={true} editMode={editing} />
+        <DeckDisplay bind:deck={corpDeck} isCorp={true} editMode={editing} />
       </div>
 
       <div class="col-md-6">
-        <DeckDisplay bind:deck={selectedRunnerDeck} isCorp={false} editMode={editing} />
+        <DeckDisplay bind:deck={runnerDeck} isCorp={false} editMode={editing} />
       </div>
     </div>
   {:else}

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -39,8 +39,14 @@
   let printings = $state(new Map<string, Printing>());
   let selectedCorpDeck = $state<Deck | null>(null);
   let selectedRunnerDeck = $state<Deck | null>(null);
+  let returnToUrl = $state("");
 
   onMount(async () => {
+    let editMode = new URLSearchParams(document.location.search).get("edit");
+    returnToUrl = editMode === "true"
+      ? `/beta/tournaments/${tournamentId}/rounds`
+      : `/beta/tournaments/${tournamentId}`;
+
     // Load printings and hydrate decks
     const printingsResponse = await loadPrintings();
     if (printingsResponse) {
@@ -166,9 +172,12 @@
       <div class="d-flex justify-content-between">
         <h5>My Registration Information</h5>
         <span class="float-right dontprint">
-          <button type="button" class="btn btn-link p-0" onclick={() => { window.print(); }}>
+          <button type="button" class="btn btn-link p-0 mr-3" title="Print" onclick={() => { window.print(); }}>
             <FontAwesomeIcon icon="print" />
           </button>
+          <a href={returnToUrl} class="btn btn-link p-0" title="Cancel">
+            <FontAwesomeIcon icon="undo" />
+          </a>
         </span>
       </div>
     </div>

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -55,29 +55,12 @@
     await loadTournamentDecks();
 
     // Load printings and convert NrdbDecks to Decks
-    const loadedDecks: Deck[] = [];
     if (nrdbDecks.length > 0) {
       const printings = await getPrintings();
       if (printings.size > 0) {
-        nrdbDecks.forEach((nrdbDeck: NrdbDeck) => {
-          const deck = convertNrdbDeck(nrdbDeck, printings);
-          deck.cards.sort((a, b) => {
-            if (a.card_type_id != b.card_type_id) {
-              return a.card_type_id < b.card_type_id ? -1 : 1;
-            }
-
-            if (a.title !== b.title) {
-              return a.title < b.title ? -1 : 1;
-            }
-
-            return 0;
-          });
-
-          loadedDecks.push(deck);
-        });
+        decks = nrdbDecks.map((d) => convertNrdbDeck(d, printings));
       }
     }
-    decks = loadedDecks;
   });
 
   async function loadTournamentDecks() {

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -101,7 +101,7 @@
       name: runnerDeck.details.identity_title ?? "",
       faction: runnerDeck.details.faction_id,
     };
-    player = await savePlayer(tournamentId, player);
+    player = await savePlayer(tournamentId, player, tournament && player.user_id !== tournament.user_id);
 
     await loadTournamentDecks();
 

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
-  import { loadTournament, Tournament } from "../tournaments/TournamentSettings";
+  import {
+    loadTournament,
+    Tournament,
+  } from "../tournaments/TournamentSettings";
   import { loadPlayer, Player } from "./PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import ProgressButton from "../widgets/ProgressButton.svelte";

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -163,7 +163,14 @@
 {#if player.id !== 0 && tournament}
   <div class="card mb-3">
     <div class="card-header">
-      <h5>My Registration Information</h5>
+      <div class="d-flex justify-content-between">
+        <h5>My Registration Information</h5>
+        <span class="float-right dontprint">
+          <button type="button" class="btn btn-link p-0" onclick={() => { window.print(); }}>
+            <FontAwesomeIcon icon="print" />
+          </button>
+        </span>
+      </div>
     </div>
 
     <div class="card-body">
@@ -210,7 +217,7 @@
         {/if}
       </div>
 
-      <div class="text-right">
+      <div class="text-right dontprint">
         <!-- Create/Save -->
         <ProgressButton
           css="btn btn-success"

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -14,10 +14,10 @@
     loadPrintings,
     Deck,
     convertNrdbDeck,
-  } from "../utils/decks";
+    getPrintings,
+  } from "../utils/decks.svelte";
   import { loadDecks, savePlayer } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
-  import type { Printing } from "../lib/api_types";
 
   let {
     tournamentId,
@@ -36,7 +36,6 @@
   let player = $state<Player | null>(null);
   let decks = $state<Deck[] | null>(null);
   let tournamentDecks = $state<Deck[]>();
-  let printings = $state(new Map<string, Printing>());
   let selectedCorpDeck = $state<Deck | null>(null);
   let selectedRunnerDeck = $state<Deck | null>(null);
   let editMode = $state(new URLSearchParams(document.location.search).get("edit") === "true");
@@ -50,10 +49,8 @@
     // Load printings and hydrate decks
     const loadedDecks: Deck[] = [];
     if (nrdbDecks.length > 0) {
-      const printingsResponse = await loadPrintings();
-      if (printingsResponse) {
-        printingsResponse.data.forEach((p) => printings.set(p.id, p));
-
+      const printings = await getPrintings();
+      if (printings.size > 0) {
         nrdbDecks.forEach((nrdbDeck: NrdbDeck) => {
           const deck = convertNrdbDeck(nrdbDeck, printings);
           deck.cards.sort((a, b) => {

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
-  import {
-    loadPlayer,
-    loadTournament,
-    Tournament,
-  } from "../tournaments/TournamentSettings";
-  import { Player } from "./PlayersData";
+  import { loadTournament, Tournament } from "../tournaments/TournamentSettings";
+  import { loadPlayer, Player } from "./PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import ProgressButton from "../widgets/ProgressButton.svelte";
   import {

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -33,20 +33,15 @@
   const THE_SYNDICATE_NRDB_CODE = "30077";
 
   let tournament = $state<Tournament | undefined>();
-  let player = $state(new Player());
+  let player = $state<Player | null>(null);
   let decks = $state<Deck[] | null>(null);
   let tournamentDecks = $state<Deck[]>();
   let printings = $state(new Map<string, Printing>());
   let selectedCorpDeck = $state<Deck | null>(null);
   let selectedRunnerDeck = $state<Deck | null>(null);
-  let returnToUrl = $state("");
+  let editMode = $state(new URLSearchParams(document.location.search).get("edit") === "true");
 
   onMount(async () => {
-    let editMode = new URLSearchParams(document.location.search).get("edit");
-    returnToUrl = editMode === "true"
-      ? `/beta/tournaments/${tournamentId}/rounds`
-      : `/beta/tournaments/${tournamentId}`;
-    
     [tournament, player] = await Promise.all([
       loadTournament(tournamentId),
       loadPlayer(tournamentId, userId),
@@ -54,38 +49,44 @@
 
     // Load printings and hydrate decks
     const loadedDecks: Deck[] = [];
-    const printingsResponse = await loadPrintings();
-    if (printingsResponse) {
-      printingsResponse.data.forEach((p) => printings.set(p.id, p));
+    if (nrdbDecks.length > 0) {
+      const printingsResponse = await loadPrintings();
+      if (printingsResponse) {
+        printingsResponse.data.forEach((p) => printings.set(p.id, p));
 
-      nrdbDecks.forEach((nrdbDeck: NrdbDeck) => {
-        const deck = convertNrdbDeck(nrdbDeck, printings);
-        deck.cards.sort((a, b) => {
-          if (a.card_type_id != b.card_type_id) {
-            return a.card_type_id < b.card_type_id ? -1 : 1;
-          }
+        nrdbDecks.forEach((nrdbDeck: NrdbDeck) => {
+          const deck = convertNrdbDeck(nrdbDeck, printings);
+          deck.cards.sort((a, b) => {
+            if (a.card_type_id != b.card_type_id) {
+              return a.card_type_id < b.card_type_id ? -1 : 1;
+            }
 
-          if (a.title !== b.title) {
-            return a.title < b.title ? -1 : 1;
-          }
+            if (a.title !== b.title) {
+              return a.title < b.title ? -1 : 1;
+            }
 
-          return 0;
+            return 0;
+          });
+
+          loadedDecks.push(deck);
         });
-
-        loadedDecks.push(deck);
-      });
+      }
     }
 
-    tournamentDecks = await loadDecks(tournamentId, player.id);
-    selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
-    selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
+    if (player) {
+      tournamentDecks = await loadDecks(tournamentId, player.id);
+      selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
+      selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
+    }
     decks = loadedDecks;
   });
 
   async function save() {
-    player.corp_deck = selectedCorpDeck ?? undefined;
-    player.runner_deck = selectedRunnerDeck ?? undefined;
-    player = await savePlayer(tournamentId, player);
+    if (player) {
+      player.corp_deck = selectedCorpDeck ?? undefined;
+      player.runner_deck = selectedRunnerDeck ?? undefined;
+      player = await savePlayer(tournamentId, player);
+    }
     return true;
   }
 
@@ -170,16 +171,21 @@
   {/if}
 {/snippet}
 
-{#if player.id !== 0 && tournament}
+{#if player && player.id !== 0 && tournament}
   <div class="card mb-3">
     <div class="card-header">
       <div class="d-flex justify-content-between">
-        <h5>My Registration Information</h5>
+        <h5 class="mb-0">My Registration Information</h5>
         <span class="float-right dontprint">
           <button type="button" class="btn btn-link p-0 mr-3" title="Print" onclick={() => { window.print(); }}>
             <FontAwesomeIcon icon="print" />
           </button>
-          <a href={returnToUrl} class="btn btn-link p-0" title="Cancel">
+          <a href={editMode
+            ? `/beta/tournaments/${tournamentId}/rounds`
+            : `/beta/tournaments/${tournamentId}`}
+            class="btn btn-link p-0"
+            title="Cancel"
+          >
             <FontAwesomeIcon icon="undo" />
           </a>
         </span>
@@ -249,44 +255,52 @@
     Please ensure your decks are legal.
   </div>
 
-  <div class="alert alert-secondary dontprint">
-    Please select from your decks below. <a
-      href="https://netrunnerdb.com/en/decks"
-      target="_blank">See your decks in NetrunnerDB</a
-    >. Refresh the page to reload from NetrunnerDB.
-  </div>
+  {#if !editMode}
+    <div class="alert alert-secondary dontprint">
+      Please select from your decks below. <a
+        href="https://netrunnerdb.com/en/decks"
+        target="_blank">See your decks in NetrunnerDB</a
+      >. Refresh the page to reload from NetrunnerDB.
+    </div>
 
-  <div class="row mb-3 justify-content-center dontprint">
-    {#if decks !== null}
-      <!-- Corp deck selection -->
-      <div class="col-md-6">
-        <div class="card">
-          <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-          {@render decksList(true, selectedCorpDeck)}
+    <div class="row mb-3 justify-content-center dontprint">
+      {#if decks !== null}
+        <!-- Corp deck selection -->
+        <div class="col-md-6">
+          <div class="card">
+            <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
+            {@render decksList(true, selectedCorpDeck)}
+          </div>
         </div>
+
+        <!-- Runner deck selection -->
+        <div class="col-md-6">
+          <div class="card">
+            <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
+            {@render decksList(false, selectedRunnerDeck)}
+          </div>
+        </div>
+      {:else}
+        <div class="spinner-border m-auto"></div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if selectedCorpDeck && selectedRunnerDeck}
+    <div class="row">
+      <div class="col-md-6">
+        <DeckDisplay deck={selectedCorpDeck} isCorp={true} />
       </div>
 
-      <!-- Runner deck selection -->
       <div class="col-md-6">
-        <div class="card">
-          <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-          {@render decksList(false, selectedRunnerDeck)}
-        </div>
+        <DeckDisplay deck={selectedRunnerDeck} isCorp={false} />
       </div>
-    {:else}
+    </div>
+  {:else}
+    <div class="d-flex align-items-center m-2">
       <div class="spinner-border m-auto"></div>
-    {/if}
-  </div>
-
-  <div class="row">
-    <div class="col-md-6">
-      <DeckDisplay deck={selectedCorpDeck} isCorp={true} />
     </div>
-
-    <div class="col-md-6">
-      <DeckDisplay deck={selectedRunnerDeck} isCorp={false} />
-    </div>
-  </div>
+  {/if}
 {:else}
   <div class="d-flex align-items-center m-2">
     <div class="spinner-border m-auto"></div>

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -68,12 +68,15 @@
       loadTournament(tournamentId),
       loadPlayer(tournamentId, userId),
     ]);
+
     tournamentDecks = await loadDecks(tournamentId, player.id);
     selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
     selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
   });
 
   async function save() {
+    player.corp_deck = selectedCorpDeck ?? undefined;
+    player.runner_deck = selectedRunnerDeck ?? undefined;
     player = await savePlayer(tournamentId, player);
     return true;
   }

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -15,7 +15,7 @@
     getPrintings,
   } from "../utils/decks.svelte";
   import {
-    loadDecks as loadDecksRequest,
+    loadDecks,
     savePlayer,
   } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
@@ -52,7 +52,9 @@
       loadPlayer(tournamentId, playerId),
     ]);
 
-    // Load printings and hydrate decks
+    await loadTournamentDecks();
+
+    // Load printings and convert NrdbDecks to Decks
     const loadedDecks: Deck[] = [];
     if (nrdbDecks.length > 0) {
       const printings = await getPrintings();
@@ -75,18 +77,15 @@
         });
       }
     }
-
-    await loadDecks();
-
     decks = loadedDecks;
   });
 
-  async function loadDecks() {
+  async function loadTournamentDecks() {
     if (!player) {
       return;
     }
 
-    tournamentDecks = await loadDecksRequest(tournamentId, player.id);
+    tournamentDecks = await loadDecks(tournamentId, player.id);
     originalCorpDeck =
       tournamentDecks.find((d) => d.details.side_id === "corp") ?? new Deck();
     originalRunnerDeck =
@@ -121,7 +120,7 @@
     };
     player = await savePlayer(tournamentId, player);
 
-    await loadDecks();
+    await loadTournamentDecks();
 
     return true;
   }

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -34,7 +34,7 @@
 
   let tournament = $state<Tournament | undefined>();
   let player = $state(new Player());
-  let decks = $state<Deck[]>([]);
+  let decks = $state<Deck[] | null>(null);
   let tournamentDecks = $state<Deck[]>();
   let printings = $state(new Map<string, Printing>());
   let selectedCorpDeck = $state<Deck | null>(null);
@@ -46,8 +46,14 @@
     returnToUrl = editMode === "true"
       ? `/beta/tournaments/${tournamentId}/rounds`
       : `/beta/tournaments/${tournamentId}`;
+    
+    [tournament, player] = await Promise.all([
+      loadTournament(tournamentId),
+      loadPlayer(tournamentId, userId),
+    ]);
 
     // Load printings and hydrate decks
+    const loadedDecks: Deck[] = [];
     const printingsResponse = await loadPrintings();
     if (printingsResponse) {
       printingsResponse.data.forEach((p) => printings.set(p.id, p));
@@ -66,18 +72,14 @@
           return 0;
         });
 
-        decks.push(deck);
+        loadedDecks.push(deck);
       });
     }
-
-    [tournament, player] = await Promise.all([
-      loadTournament(tournamentId),
-      loadPlayer(tournamentId, userId),
-    ]);
 
     tournamentDecks = await loadDecks(tournamentId, player.id);
     selectedCorpDeck = tournamentDecks.find(((d) => d.details.side_id === "corp")) ?? null;
     selectedRunnerDeck = tournamentDecks.find(((d) => d.details.side_id === "runner")) ?? null;
+    decks = loadedDecks;
   });
 
   async function save() {
@@ -126,44 +128,46 @@
 {/snippet}
 
 {#snippet decksList(isCorp: boolean, selectedDeck: Deck | null)}
-  <ul class="list-group list-group-flush" style="border-bottom: 0;">
-    <li class="list-group-item selected-deck">
-      <div class="selected-deck-buttons">
-        <!-- TODO: Undo -->
+  {#if decks !== null}
+    <ul class="list-group list-group-flush" style="border-bottom: 0;">
+      <li class="list-group-item selected-deck">
+        <div class="selected-deck-buttons">
+          <!-- TODO: Undo -->
+          {#if selectedDeck}
+            <button
+              type="button"
+              title="Deselect"
+              class="btn btn-link p-0"
+              onclick={() => {
+                selectDeck(null, isCorp);
+              }}
+            >
+              <FontAwesomeIcon icon="close" />
+            </button>
+          {/if}
+        </div>
         {#if selectedDeck}
-          <button
-            type="button"
-            title="Deselect"
-            class="btn btn-link p-0"
-            onclick={() => {
-              selectDeck(null, isCorp);
-            }}
-          >
-            <FontAwesomeIcon icon="close" />
-          </button>
+          <div
+            class="selected-deck-identity"
+            style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${selectedDeck.details.identity_nrdb_printing_id}.jpg)`}
+          ></div>
+          <p class="mb-1">{selectedDeck.details.name}</p>
+        {:else}
+          <div
+            class="selected-deck-identity"
+            style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${isCorp ? THE_SYNDICATE_NRDB_CODE : THE_CATALYST_NRDB_CODE}.jpg)`}
+          ></div>
+          <p class="mb-1">{isCorp ? "No corp selected" : "No runner selected"}</p>
         {/if}
-      </div>
-      {#if selectedDeck}
-        <div
-          class="selected-deck-identity"
-          style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${selectedDeck.details.identity_nrdb_printing_id}.jpg)`}
-        ></div>
-        <p class="mb-1">{selectedDeck.details.name}</p>
-      {:else}
-        <div
-          class="selected-deck-identity"
-          style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${isCorp ? THE_SYNDICATE_NRDB_CODE : THE_CATALYST_NRDB_CODE}.jpg)`}
-        ></div>
-        <p class="mb-1">{isCorp ? "No corp selected" : "No runner selected"}</p>
-      {/if}
-    </li>
-  </ul>
-  <ul class="list-group list-group-flush overflow-auto" style="height: 24em;">
-    {#each decks.filter((d) => d.details.side_id === (isCorp ? "corp" : "runner")) as deck (deck.details.id)}
-      <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-      {@render deckListItem(deck, isCorp)}
-    {/each}
-  </ul>
+      </li>
+    </ul>
+    <ul class="list-group list-group-flush overflow-auto" style="height: 24em;">
+      {#each decks.filter((d) => d.details.side_id === (isCorp ? "corp" : "runner")) as deck (deck.details.id)}
+        <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
+        {@render deckListItem(deck, isCorp)}
+      {/each}
+    </ul>
+  {/if}
 {/snippet}
 
 {#if player.id !== 0 && tournament}
@@ -252,22 +256,26 @@
     >. Refresh the page to reload from NetrunnerDB.
   </div>
 
-  <div class="row mb-3 dontprint">
-    <!-- Corp deck selection -->
-    <div class="col-md-6">
-      <div class="card">
-        <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-        {@render decksList(true, selectedCorpDeck)}
+  <div class="row mb-3 justify-content-center dontprint">
+    {#if decks !== null}
+      <!-- Corp deck selection -->
+      <div class="col-md-6">
+        <div class="card">
+          <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
+          {@render decksList(true, selectedCorpDeck)}
+        </div>
       </div>
-    </div>
 
-    <!-- Runner deck selection -->
-    <div class="col-md-6">
-      <div class="card">
-        <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
-        {@render decksList(false, selectedRunnerDeck)}
+      <!-- Runner deck selection -->
+      <div class="col-md-6">
+        <div class="card">
+          <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
+          {@render decksList(false, selectedRunnerDeck)}
+        </div>
       </div>
-    </div>
+    {:else}
+      <div class="spinner-border m-auto"></div>
+    {/if}
   </div>
 
   <div class="row">

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -11,7 +11,6 @@
   import ProgressButton from "../widgets/ProgressButton.svelte";
   import {
     type NrdbDeck,
-    loadPrintings,
     Deck,
     convertNrdbDeck,
     getPrintings,
@@ -36,9 +35,10 @@
   let player = $state<Player | null>(null);
   let decks = $state<Deck[] | null>(null);
   let tournamentDecks = $state<Deck[]>();
-  let selectedCorpDeck = $state<Deck | null>(null);
-  let selectedRunnerDeck = $state<Deck | null>(null);
+  let selectedCorpDeck = $state(new Deck());
+  let selectedRunnerDeck = $state(new Deck());
   let editMode = $state(new URLSearchParams(document.location.search).get("edit") === "true");
+  let editing = $state(false);
 
   onMount(async () => {
     [tournament, player] = await Promise.all([
@@ -78,6 +78,15 @@
     decks = loadedDecks;
   });
 
+  function toggleEditing() {
+    // TODO: Update edit mode for DeckDisplay components
+    editing = !editing;
+
+    // TODO: Do the following:
+    // - Create edit copies of selected decks
+    // - Reset edit copies if edit mode is cancelled
+  }
+
   async function save() {
     if (player) {
       player.corp_deck = selectedCorpDeck ?? undefined;
@@ -87,16 +96,16 @@
     return true;
   }
 
-  function selectDeck(deck: Deck | null, isCorp: boolean) {
+  function selectDeck(deck: Deck, isCorp: boolean) {
     if (isCorp) {
       selectedCorpDeck =
         deck && deck.details.nrdb_uuid === selectedCorpDeck?.details.nrdb_uuid
-          ? null
+          ? new Deck()
           : deck;
     } else {
       selectedRunnerDeck =
         deck && deck.details.nrdb_uuid === selectedRunnerDeck?.details.nrdb_uuid
-          ? null
+          ? new Deck()
           : deck;
     }
   }
@@ -137,7 +146,7 @@
               title="Deselect"
               class="btn btn-link p-0"
               onclick={() => {
-                selectDeck(null, isCorp);
+                selectDeck(new Deck(), isCorp);
               }}
             >
               <FontAwesomeIcon icon="close" />
@@ -233,16 +242,38 @@
         {/if}
       </div>
 
-      <div class="text-right dontprint">
-        <!-- Create/Save -->
-        <ProgressButton
-          css="btn btn-success"
-          inProgressText="Saving"
-          completeText="Saved"
-          onclick={save}
-        >
-          <FontAwesomeIcon icon="floppy-o" /> Save
-        </ProgressButton>
+      <div class="dontprint mt-sm-2">
+        {#if editMode}
+          <div class="float-left">
+            {#if editing}
+              <button type="button" class="btn btn-link" onclick={toggleEditing}>
+                <FontAwesomeIcon icon="undo" />
+                Cancel edits
+              </button>
+            {:else}
+              <a href="/beta/tournaments/{tournamentId}/registration" class="btn btn-link">
+                <FontAwesomeIcon icon="edit" />
+                Choose decks from your NetrunnerDB account
+              </a>
+              <button type="button" class="btn btn-link" onclick={toggleEditing}>
+                <FontAwesomeIcon icon="edit" />
+                Edit decks in place
+              </button>
+            {/if}
+          </div>
+        {/if}
+
+        <div class="float-right">
+          <!-- Create/Save -->
+          <ProgressButton
+            css="btn btn-success"
+            inProgressText="Saving"
+            completeText="Saved"
+            onclick={save}
+          >
+            <FontAwesomeIcon icon="floppy-o" /> Save
+          </ProgressButton>
+        </div>
       </div>
     </div>
   </div>
@@ -286,11 +317,11 @@
   {#if selectedCorpDeck && selectedRunnerDeck}
     <div class="row">
       <div class="col-md-6">
-        <DeckDisplay deck={selectedCorpDeck} isCorp={true} />
+        <DeckDisplay bind:deck={selectedCorpDeck} isCorp={true} editMode={editing} />
       </div>
 
       <div class="col-md-6">
-        <DeckDisplay deck={selectedRunnerDeck} isCorp={false} />
+        <DeckDisplay bind:deck={selectedRunnerDeck} isCorp={false} editMode={editing} />
       </div>
     </div>
   {:else}

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -104,6 +104,7 @@
     player = await savePlayer(tournamentId, player, tournament && player.user_id !== tournament.user_id);
 
     await loadTournamentDecks();
+    toggleEditing();
 
     return true;
   }

--- a/app/frontend/tests/Tournament.svelte-test.ts
+++ b/app/frontend/tests/Tournament.svelte-test.ts
@@ -10,18 +10,16 @@ import Tournament from "../tournaments/Tournament.svelte";
 import { MockIdentityNames, MockTournament } from "./TournamentTestData";
 import { MockPlayerBob } from "./RoundsTestData";
 import {
-  loadPlayer,
   loadQRCode,
   loadTournament,
 } from "../tournaments/TournamentSettings";
 import { loadIdentityNames } from "../identities/Identity";
 import userEvent from "@testing-library/user-event";
-import { Player, savePlayer } from "../players/PlayersData";
+import { loadPlayerByUserId, Player, savePlayer } from "../players/PlayersData";
 
 vi.mock("../tournaments/TournamentSettings", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../pairings/PairingsData")>()),
   loadTournament: vi.fn(() => MockTournament),
-  loadPlayer: vi.fn(() => MockPlayerBob),
   loadQRCode: vi.fn(() => null),
 }));
 
@@ -32,6 +30,7 @@ vi.mock("../identities/Identity", async (importOriginal) => ({
 
 vi.mock("../players/PlayersData", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../pairings/PairingsData")>()),
+  loadPlayerByUserId: vi.fn(() => MockPlayerBob),
   savePlayer: vi.fn(() => true),
 }));
 
@@ -45,7 +44,7 @@ describe("Tournament", () => {
       expect(loadTournament).toHaveBeenCalledOnce();
     });
     await waitFor(() => {
-      expect(loadPlayer).toHaveBeenCalledOnce();
+      expect(loadPlayerByUserId).toHaveBeenCalledOnce();
     });
     await waitFor(() => {
       expect(loadQRCode).toHaveBeenCalledOnce();
@@ -75,7 +74,7 @@ describe("Tournament", () => {
 
   describe("when player is logged out", () => {
     beforeEach(() => {
-      vi.mocked(loadPlayer).mockImplementation(() =>
+      vi.mocked(loadPlayerByUserId).mockImplementation(() =>
         Promise.resolve(new Player()),
       );
     });
@@ -143,7 +142,7 @@ describe("Tournament", () => {
   describe("when player is logged in", () => {
     describe("when player is not registered", () => {
       beforeEach(async () => {
-        vi.mocked(loadPlayer).mockImplementation(() =>
+        vi.mocked(loadPlayerByUserId).mockImplementation(() =>
           Promise.resolve(new Player()),
         );
 

--- a/app/frontend/tests/Tournament.svelte-test.ts
+++ b/app/frontend/tests/Tournament.svelte-test.ts
@@ -9,10 +9,7 @@ import {
 import Tournament from "../tournaments/Tournament.svelte";
 import { MockIdentityNames, MockTournament } from "./TournamentTestData";
 import { MockPlayerBob } from "./RoundsTestData";
-import {
-  loadQRCode,
-  loadTournament,
-} from "../tournaments/TournamentSettings";
+import { loadQRCode, loadTournament } from "../tournaments/TournamentSettings";
 import { loadIdentityNames } from "../identities/Identity";
 import userEvent from "@testing-library/user-event";
 import { loadPlayerByUserId, Player, savePlayer } from "../players/PlayersData";

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -23,7 +23,7 @@
   } = $props();
 
   let tournament: Tournament | undefined = $state();
-  let player: Player | undefined = $state();
+  let player: Player | null = $state(null);
   let notices: string[] = $state([]);
 
   let qrCodeImageData = $state("");
@@ -34,21 +34,21 @@
 
     qrCodeImageData = URL.createObjectURL(await loadQRCode(tournamentId));
 
-    if (player.id === 0) {
+    if (player?.id === 0) {
       player.name = userName ?? "";
     }
 
     if (tournament.nrdb_deck_registration) {
       if (
         !tournament.registration_closed &&
-        (player.id === 0 || !player.registration_locked)
+        (player?.id === 0 || !player?.registration_locked)
       ) {
         notices.push("Registration is open.");
       }
       if (userId === tournament.user_id && tournament.any_player_unlocked) {
         notices.push("One or more players are unlocked for editing.");
       }
-      if (player.id !== 0 && !player.registration_locked) {
+      if (player?.id !== 0 && !player?.registration_locked) {
         notices.push("Your registration is editable.");
       }
     }

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
-  import {
-    loadQRCode,
-    loadTournament,
-    Tournament,
-  } from "./TournamentSettings";
+  import { loadQRCode, loadTournament, Tournament } from "./TournamentSettings";
   import { loadPlayerByUserId, Player } from "../players/PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import RegistrationCard from "../players/RegistrationCard.svelte";

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
   import {
-    loadPlayer,
+    loadPlayerByUserId,
     loadQRCode,
     loadTournament,
     Tournament,
@@ -30,7 +30,7 @@
 
   onMount(async () => {
     tournament = await loadTournament(tournamentId);
-    player = await loadPlayer(tournamentId, userId);
+    player = await loadPlayerByUserId(tournamentId, userId);
 
     qrCodeImageData = URL.createObjectURL(await loadQRCode(tournamentId));
 

--- a/app/frontend/tournaments/Tournament.svelte
+++ b/app/frontend/tournaments/Tournament.svelte
@@ -2,12 +2,11 @@
   import { onMount } from "svelte";
   import GlobalMessages from "../widgets/GlobalMessages.svelte";
   import {
-    loadPlayerByUserId,
     loadQRCode,
     loadTournament,
     Tournament,
   } from "./TournamentSettings";
-  import { Player } from "../players/PlayersData";
+  import { loadPlayerByUserId, Player } from "../players/PlayersData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import RegistrationCard from "../players/RegistrationCard.svelte";
   import ModalDialog from "../widgets/ModalDialog.svelte";

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -1,4 +1,5 @@
-import type { Player } from "../players/PlayersData";
+import { Player } from "../players/PlayersData";
+import { globalMessages } from "../utils/GlobalMessageState.svelte";
 
 export type Errors = Record<string, string[]>;
 
@@ -157,10 +158,7 @@ export async function loadTournament(
   return tournament;
 }
 
-export async function loadPlayer(
-  tournamentId: number,
-  userId: number,
-): Promise<Player> {
+export async function loadPlayer(tournamentId: number, userId: number) {
   const response = await fetch(
     `/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
     {
@@ -168,7 +166,15 @@ export async function loadPlayer(
     },
   );
 
-  return (await response.json()) as Player;
+  let player: Player;
+  try {
+    player = (await response.json()) as Player;
+  } catch {
+    globalMessages.warnings.push(`Player data for user ${userId} could not be loaded.`);
+    return null;
+  }
+
+  return player;
 }
 
 export async function loadNewTournament(): Promise<TournamentSettingsData> {

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -158,23 +158,36 @@ export async function loadTournament(
   return tournament;
 }
 
-export async function loadPlayer(tournamentId: number, userId: number) {
-  const response = await fetch(
-    `/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
-    {
-      method: "GET",
-    },
-  );
-
-  let player: Player;
+export async function loadPlayer(tournamentId: number, playerId: number) {
   try {
-    player = (await response.json()) as Player;
+    const response = await fetch(
+      `/beta/tournaments/${tournamentId}/players/${playerId}`,
+      {
+        method: "GET",
+      },
+    );
+
+    return  (await response.json()) as Player;
   } catch {
-    globalMessages.warnings.push(`Player data for user ${userId} could not be loaded.`);
+    globalMessages.errors.push(`Error loading player data for player ${playerId}`);
     return null;
   }
+}
 
-  return player;
+export async function loadPlayerByUserId(tournamentId: number, userId: number) {
+  try {
+    const response = await fetch(
+      `/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
+      {
+        method: "GET",
+      },
+    );
+
+    return (await response.json()) as Player;
+  } catch {
+    globalMessages.errors.push(`Error loading player data for user ${userId}.`);
+    return null;
+  }
 }
 
 export async function loadNewTournament(): Promise<TournamentSettingsData> {

--- a/app/frontend/tournaments/TournamentSettings.ts
+++ b/app/frontend/tournaments/TournamentSettings.ts
@@ -1,6 +1,3 @@
-import { Player } from "../players/PlayersData";
-import { globalMessages } from "../utils/GlobalMessageState.svelte";
-
 export type Errors = Record<string, string[]>;
 
 declare const Routes: {
@@ -156,38 +153,6 @@ export async function loadTournament(
   tournament.id = parseInt(apiTournament.data.id);
 
   return tournament;
-}
-
-export async function loadPlayer(tournamentId: number, playerId: number) {
-  try {
-    const response = await fetch(
-      `/beta/tournaments/${tournamentId}/players/${playerId}`,
-      {
-        method: "GET",
-      },
-    );
-
-    return  (await response.json()) as Player;
-  } catch {
-    globalMessages.errors.push(`Error loading player data for player ${playerId}`);
-    return null;
-  }
-}
-
-export async function loadPlayerByUserId(tournamentId: number, userId: number) {
-  try {
-    const response = await fetch(
-      `/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
-      {
-        method: "GET",
-      },
-    );
-
-    return (await response.json()) as Player;
-  } catch {
-    globalMessages.errors.push(`Error loading player data for user ${userId}.`);
-    return null;
-  }
 }
 
 export async function loadNewTournament(): Promise<TournamentSettingsData> {

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -2,6 +2,19 @@ import type { Printing, PrintingsResponse } from "../lib/api_types";
 import { quoteCsvValue } from "./files";
 import { globalMessages } from "./GlobalMessageState.svelte";
 
+const printings = $state(new Map<string, Printing>());
+
+export async function getPrintings() {
+  if (printings.size === 0) {
+    const response = await loadPrintings();
+    if (response) {
+      response.data.forEach((p) => printings.set(p.id, p));
+    }
+  }
+
+  return printings;
+}
+
 export interface NrdbCard {
   id: string;
   count: number;

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -225,11 +225,11 @@ export async function loadPrintings(query?: string) {
 
     if (response.status === 200) {
       return (await response.json()) as PrintingsResponse;
-    } else {
-      globalMessages.errors.push(
-        `Failed to load printings: ${response.statusText}`,
-      );
     }
+
+    globalMessages.errors.push(
+      `Failed to load printings: ${response.statusText}`,
+    );
   } catch (e) {
     const err = e as Error;
     globalMessages.errors.push(`Failed to load printings: ${err.message}`);

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -196,6 +196,20 @@ export function deckCsv(decks: Deck[]) {
   return `\ufeff${headerCsv}\n\n${cardCsv}`;
 }
 
+export function sortCards(cards: Card[]) {
+  cards.sort((a, b) => {
+    if (a.card_type_id != b.card_type_id) {
+      return a.card_type_id < b.card_type_id ? -1 : 1;
+    }
+
+    if (a.title !== b.title) {
+      return a.title < b.title ? -1 : 1;
+    }
+
+    return 0;
+  });
+}
+
 export async function loadPrintings(query?: string) {
   let queryString =
     "fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost";

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -197,7 +197,8 @@ export function deckCsv(decks: Deck[]) {
 }
 
 export async function loadPrintings(query?: string) {
-  let queryString = "fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost";
+  let queryString =
+    "fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost";
   if (queryString) {
     queryString += `&${query}`;
   }
@@ -205,7 +206,7 @@ export async function loadPrintings(query?: string) {
   try {
     const response = await fetch(
       `https://api.netrunnerdb.com/api/v3/public/printings?${queryString}`,
-      { method: "GET", },
+      { method: "GET" },
     );
 
     if (response.status === 200) {

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -6,7 +6,7 @@ const printings = $state(new Map<string, Printing>());
 
 export async function getPrintings() {
   if (printings.size === 0) {
-    const response = await loadPrintings();
+    const response = await loadPrintings("page[size]=10000");
     if (response) {
       response.data.forEach((p) => printings.set(p.id, p));
     }
@@ -58,8 +58,8 @@ export class DeckDetails {
   max_influence: number | null = null;
   nrdb_uuid: string | null = null;
   identity_nrdb_card_id: string | null = null;
-  created_at: string = "";
-  updated_at: string = "";
+  created_at = "";
+  updated_at = "";
   identity_nrdb_printing_id: string | null = null;
   user_id: number | null = null;
   faction_id: string | null = null;
@@ -196,17 +196,20 @@ export function deckCsv(decks: Deck[]) {
   return `\ufeff${headerCsv}\n\n${cardCsv}`;
 }
 
-export async function loadPrintings() {
-  let data: PrintingsResponse | null = null;
+export async function loadPrintings(query?: string) {
+  let queryString = "fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost";
+  if (queryString) {
+    queryString += `&${query}`;
+  }
 
   try {
     const response = await fetch(
-      "https://api.netrunnerdb.com/api/v3/public/printings?page[size]=10000&fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost",
-      { method: "GET" },
+      `https://api.netrunnerdb.com/api/v3/public/printings?${queryString}`,
+      { method: "GET", },
     );
 
     if (response.status === 200) {
-      data = (await response.json()) as PrintingsResponse;
+      return (await response.json()) as PrintingsResponse;
     } else {
       globalMessages.errors.push(
         `Failed to load printings: ${response.statusText}`,
@@ -217,5 +220,5 @@ export async function loadPrintings() {
     globalMessages.errors.push(`Failed to load printings: ${err.message}`);
   }
 
-  return data;
+  return null;
 }

--- a/app/frontend/utils/decks.ts
+++ b/app/frontend/utils/decks.ts
@@ -21,7 +21,7 @@ export interface NrdbDeck {
 }
 
 export interface Card {
-  id: number;
+  id: string;
   deck_id: number;
   title: string;
   quantity: number;
@@ -29,7 +29,7 @@ export interface Card {
   nrdb_card_id: string;
   created_at: string;
   updated_at: string;
-  nrdb_printing_id: number | null;
+  nrdb_printing_id: string | null;
   card_type_id: string;
   faction_id: string;
   influence_cost: number;
@@ -48,7 +48,7 @@ export interface Deck {
     identity_nrdb_card_id: string;
     created_at: string;
     updated_at: string;
-    identity_nrdb_printing_id: number | null;
+    identity_nrdb_printing_id: string | null;
     user_id: number;
     faction_id: string;
     mine: boolean;
@@ -61,7 +61,7 @@ export function convertNrdbDeck(
   nrdbDeck: NrdbDeck,
   printings: Map<string, Printing>,
 ): Deck {
-  let identityNrdbId = 0;
+  let identityNrdbId = "";
   let identity: Printing | null = null;
   const cards: Card[] = [];
   nrdbDeck.cards.forEach((card: NrdbCard) => {
@@ -71,13 +71,13 @@ export function convertNrdbDeck(
     }
 
     if (printing.attributes.card_type_id.endsWith("identity")) {
-      identityNrdbId = parseInt(card.id);
+      identityNrdbId = card.id;
       identity = printing;
       return;
     }
 
     cards.push({
-      id: parseInt(card.id),
+      id: card.id,
       deck_id: nrdbDeck.id,
       title: printing.attributes.title,
       quantity: card.count,
@@ -85,7 +85,7 @@ export function convertNrdbDeck(
       nrdb_card_id: printing.attributes.card_id,
       created_at: "",
       updated_at: "",
-      nrdb_printing_id: parseInt(card.id),
+      nrdb_printing_id: card.id,
       card_type_id: printing.attributes.card_type_id,
       faction_id: printing.attributes.faction_id,
       influence_cost: printing.attributes.influence_cost,

--- a/app/frontend/utils/decks.ts
+++ b/app/frontend/utils/decks.ts
@@ -147,6 +147,9 @@ export function deckCsv(decks: Deck[]) {
       "\n" +
       decks
         .map((deck: Deck) => {
+          if (i >= deck.cards.length) {
+            return ",,";
+          }
           const influence =
             deck.cards[i].influence > 0 &&
             deck.cards[i].faction_id !== deck.details.faction_id

--- a/app/frontend/utils/decks.ts
+++ b/app/frontend/utils/decks.ts
@@ -35,26 +35,28 @@ export interface Card {
   influence_cost: number;
 }
 
-export interface Deck {
-  details: {
-    id: number;
-    player_id: number;
-    side_id: string;
-    name: string | null;
-    identity_title: string;
-    min_deck_size: number;
-    max_influence: number;
-    nrdb_uuid: string | null;
-    identity_nrdb_card_id: string;
-    created_at: string;
-    updated_at: string;
-    identity_nrdb_printing_id: string | null;
-    user_id: number;
-    faction_id: string;
-    mine: boolean;
-    player_name: string;
-  };
-  cards: Card[];
+export class DeckDetails {
+  id = 0;
+  player_id: number | null = null;
+  side_id: string | null = null;
+  name: string | null = null;
+  identity_title: string | null = null;
+  min_deck_size: number | null = null;
+  max_influence: number | null = null;
+  nrdb_uuid: string | null = null;
+  identity_nrdb_card_id: string | null = null;
+  created_at: string = "";
+  updated_at: string = "";
+  identity_nrdb_printing_id: string | null = null;
+  user_id: number | null = null;
+  faction_id: string | null = null;
+  mine: boolean | null = null;
+  player_name: string | null = null;
+}
+
+export class Deck {
+  details = new DeckDetails();
+  cards: Card[] = [];
 }
 
 export function convertNrdbDeck(
@@ -121,7 +123,7 @@ export function convertNrdbDeck(
 export function deckCsv(decks: Deck[]) {
   const headerCsv =
     decks
-      .map((deck) => `Player,${quoteCsvValue(deck.details.player_name)},`)
+      .map((deck) => `Player,${quoteCsvValue(deck.details.player_name ?? "")},`)
       .join(",,") +
     "\n" +
     decks
@@ -133,7 +135,7 @@ export function deckCsv(decks: Deck[]) {
     decks
       .map(
         (deck) =>
-          `${deck.details.min_deck_size},${quoteCsvValue(deck.details.identity_title)},${deck.details.max_influence}`,
+          `${deck.details.min_deck_size},${quoteCsvValue(deck.details.identity_title ?? "")},${deck.details.max_influence}`,
       )
       .join(",,");
 

--- a/app/views/beta/players/registration.html.slim
+++ b/app/views/beta/players/registration.html.slim
@@ -1,4 +1,4 @@
-#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-user-id="#{@player&.user_id}"
+#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-player-id="#{@player&.id}"
 
 = content_for :head do
   = vite_typescript_tag 'registration', 'data-turbolinks-track': 'reload'

--- a/app/views/beta/players/registration.html.slim
+++ b/app/views/beta/players/registration.html.slim
@@ -1,0 +1,4 @@
+#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-user-id="#{@player&.user_id}"
+
+= content_for :head do
+  = vite_typescript_tag 'registration', 'data-turbolinks-track': 'reload'

--- a/app/views/beta/tournaments/registration.html.slim
+++ b/app/views/beta/tournaments/registration.html.slim
@@ -1,4 +1,4 @@
-#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-user-id="#{current_user&.id}" data-user-decks="#{@decks.to_json}"
+#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-player-id="#{@current_user_player&.id}" data-user-decks="#{@decks.to_json}"
 
 = content_for :head do
   = vite_typescript_tag 'registration', 'data-turbolinks-track': 'reload'

--- a/app/views/beta/tournaments/registration.html.slim
+++ b/app/views/beta/tournaments/registration.html.slim
@@ -1,4 +1,4 @@
-#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-player-id="#{@current_user_player&.id}" data-user-decks="#{@decks.to_json}"
+#registration_anchor.col-12 data-tournament-id="#{@tournament.id}" data-player-id="#{@current_user_player&.id}" data-user-decks="#{@decks ? @decks.to_json : ""}"
 
 = content_for :head do
   = vite_typescript_tag 'registration', 'data-turbolinks-track': 'reload'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
         patch :drop, on: :member
         patch :reinstate, on: :member
         get :decks, on: :collection
+        get :decks, on: :member
       end
       get :qr, on: :member
       get :registration, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
       resources :players, only: %i[index create update destroy] do
         get :players_data, on: :collection
         get 'by_user_id/:user_id', to: 'players#by_user_id', on: :collection
+        get :registration, on: :member
         patch :lock_registration, on: :member
         patch :unlock_registration, on: :member
         patch :drop, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
         patch :update_timer, on: :member
         get :pairings_data, on: :collection
       end
-      resources :players, only: %i[index create update destroy] do
+      resources :players, only: %i[index show create update destroy] do
         get :players_data, on: :collection
         get 'by_user_id/:user_id', to: 'players#by_user_id', on: :collection
         get :registration, on: :member

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default ts.config(
         "error",
         { allowNumber: true },
       ],
+      "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
       "eol-last": ["error", "always"],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,10 @@ export default ts.config(
         "error",
         { allowNumber: true },
       ],
-      "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { ignoreRestSiblings: true },
+      ],
       "eol-last": ["error", "always"],
     },
   },


### PR DESCRIPTION
These changes add most of the deck editing functionality to the beta version of the deck registration page. Notably, this does not include diffs when editing decks, but I intend to add that in an upcoming PR.

I suspect that there is a lot of cleanup and optimization we can do with regards to how we handle the loading of printings, but for now I'm just replicating how the current registration page works.

The functionality works to at least my basic level of programmer testing - I won't be surprised at all if there are bugs here, but I wanted to get this out before it got too bloated. Tests will also be in an upcoming PR.

Also, as far as I can tell, the beta version of the deck registration page fixes a [deck editing issue that I attempted (and failed) to fix several months ago](https://github.com/Null-Signal-Games/cobra/pull/574).