### PR TITLE
Fix player report displays for double-sided pairings

### DIFF
--- a/app/controllers/beta/rounds_controller.rb
+++ b/app/controllers/beta/rounds_controller.rb
@@ -170,34 +170,6 @@ module Beta
           self_reports = self_reports.select { |r| r['report_player_id'] == current_user.id }
         end
 
-        # TODO: Move label logic and score_label() to FE
-        if self_reports&.any? && @tournament.user != current_user
-          if stage.single_sided? && side == 'player1_is_corp'
-            self_reports.each do |r|
-              r[:label] = score_label(@tournament.swiss_format,
-                                      player1_side(side),
-                                      r['score1'],
-                                      r['score1_corp'],
-                                      r['score1_runner'],
-                                      r['score2'],
-                                      r['score2_corp'],
-                                      r['score2_runner'])
-            end
-          else
-            # Player 2 is the corp (left side) player
-            self_reports.each do |r|
-              r[:label] = score_label(@tournament.swiss_format,
-                                      player2_side(side),
-                                      r['score2'],
-                                      r['score2_corp'],
-                                      r['score2_runner'],
-                                      r['score1'],
-                                      r['score1_corp'],
-                                      r['score1_runner'])
-            end
-          end
-        end
-
         pairings << {
           id:,
           table_number:,
@@ -291,7 +263,7 @@ module Beta
 
     def score_label(swiss_format, player1_side, score1, score1_corp, score1_runner, score2, score2_corp, score2_runner) # rubocop:disable Metrics/ParameterLists
       # No scores reported.
-      return '-' if score1 == 0 && score2 == 0 # rubocop:disable Style/NumericPredicate
+      return '-' if score1&.zero? && score2&.zero?
 
       ws = winning_side(score1_corp, score1_runner, score2_corp, score2_runner)
 

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -336,7 +336,7 @@ class RoundsController < ApplicationController # rubocop:disable Metrics/ClassLe
 
   def score_label(swiss_format, player1_side, score1, score1_corp, score1_runner, score2, score2_corp, score2_runner) # rubocop:disable Metrics/ParameterLists
     # No scores reported.
-    return '-' if score1 == 0 && score2 == 0 # rubocop:disable Style/NumericPredicate
+    return '-' if score1&.zero? && score2&.zero?
 
     ws = winning_side(score1_corp, score1_runner, score2_corp, score2_runner)
 

--- a/app/frontend/pairings/Pairing.svelte
+++ b/app/frontend/pairings/Pairing.svelte
@@ -226,7 +226,11 @@
         <SelfReportOptions {stage} {pairing} {reportScoreCallback} />
       {/if}
       {#if pairing.self_reports && pairing.self_reports.length !== 0}
-        Report: {pairing.self_reports[0].label}
+        Report: {readableReportScore(
+          pairing.self_reports[0],
+          pairing.player1.side,
+          stage.is_single_sided,
+        )}
       {/if}
     </div>
   {/if}

--- a/app/frontend/tests/MyTournamentPage.svelte-test.ts
+++ b/app/frontend/tests/MyTournamentPage.svelte-test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MockPairing1,
   MockPairingsData,
-  MockSelfReport,
+  MockSelfReportPlayer1Sweep,
 } from "./RoundsTestData";
 import {
   getByRole,
@@ -74,11 +74,11 @@ describe("MyTournamentPage", () => {
           false,
         );
         vi.spyOn(MockPairing1, "self_reports", "get").mockReturnValue([
-          MockSelfReport,
+          MockSelfReportPlayer1Sweep,
         ]);
-        vi.spyOn(MockSelfReport, "score1", "get").mockReturnValue(score1);
-        vi.spyOn(MockSelfReport, "score2", "get").mockReturnValue(score2);
-        vi.spyOn(MockSelfReport, "label", "get").mockReturnValue(scoreText);
+        vi.spyOn(MockSelfReportPlayer1Sweep, "score1", "get").mockReturnValue(score1);
+        vi.spyOn(MockSelfReportPlayer1Sweep, "score2", "get").mockReturnValue(score2);
+        vi.spyOn(MockSelfReportPlayer1Sweep, "label", "get").mockReturnValue(scoreText);
 
         await waitFor(() => {
           const table = document.getElementById("rounds_table") as HTMLTableElement;

--- a/app/frontend/tests/Rounds.svelte-test.ts
+++ b/app/frontend/tests/Rounds.svelte-test.ts
@@ -20,7 +20,7 @@ import {
   updateRoundTimer,
 } from "../pairings/PairingsData";
 import Rounds from "../pairings/Rounds.svelte";
-import { reportScore } from "../pairings/SelfReport";
+import { reportScore, type ScoreReport } from "../pairings/SelfReport";
 import {
   MockDoubleElimCutStage,
   MockPairing1,
@@ -30,7 +30,10 @@ import {
   MockRound1,
   MockRound1Timer,
   MockRound2,
-  MockSelfReport,
+  MockSelfReportCorpSplit,
+  MockSelfReportPlayer1Sweep,
+  MockSelfReportPlayer2Sweep,
+  MockSelfReportRunnerSplit,
   MockSingleElimCutStage,
   MockSwissStage,
 } from "./RoundsTestData";
@@ -684,44 +687,45 @@ describe("Rounds", () => {
       });
 
       describe.each([
-        [6, 0, /6-0/i, "6 - 0"],
-        [3, 3, /3-3 \(c\)/i, "3 - 3 (c)"],
-        [3, 3, /3-3 \(r\)/i, "3 - 3 (R)"],
-        [6, 0, /0-6/i, "0 - 6"],
-      ])("using preset score", (score1, score2, buttonText, scoreText) => {
-        it(scoreText, async () => {
-          vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(
-            false,
-          );
-          vi.spyOn(MockPairing1, "self_reports", "get").mockReturnValue([
-            MockSelfReport,
-          ]);
-          vi.spyOn(MockSelfReport, "score1", "get").mockReturnValue(score1);
-          vi.spyOn(MockSelfReport, "score2", "get").mockReturnValue(score2);
-          vi.spyOn(MockSelfReport, "label", "get").mockReturnValue(scoreText);
+        [MockSelfReportPlayer1Sweep, "6-0"],
+        [MockSelfReportCorpSplit, "3-3 (C)"],
+        [MockSelfReportRunnerSplit, "3-3 (R)"],
+        [MockSelfReportPlayer2Sweep, "0-6"],
+      ])(
+        "using preset score",
+        (scoreReport: ScoreReport, buttonText: string) => {
+          it(scoreReport.label ?? "", async () => {
+            vi.spyOn(MockPairing1.policy, "self_report", "get").mockReturnValue(
+              false,
+            );
+            vi.spyOn(MockPairing1, "self_reports", "get").mockReturnValue([
+              scoreReport,
+            ]);
+            const table1Row = document.getElementsByClassName(
+              "table_1",
+            )[0] as HTMLElement;
+            await user.click(
+              getByRole(table1Row, "button", { name: /report pairing/i }),
+            );
 
-          const table1Row = document.getElementsByClassName(
-            "table_1",
-          )[0] as HTMLElement;
-          await user.click(
-            getByRole(table1Row, "button", { name: /report pairing/i }),
-          );
+            const reportDialog = document.getElementById("reportModal");
+            expect(reportDialog).not.toBeNull();
+            if (!reportDialog) {
+              return;
+            }
+            await user.click(getByText(reportDialog, buttonText));
 
-          const reportDialog = document.getElementById("reportModal");
-          expect(reportDialog).not.toBeNull();
-          if (!reportDialog) {
-            return;
-          }
-          await user.click(getByText(reportDialog, buttonText));
-
-          expect(reportScore).toHaveBeenCalledOnce();
-          expect(loadPairings).toHaveBeenCalledTimes(2);
-          expect(
-            queryByRole(table1Row, "button", { name: /report pairing/i }),
-          ).toBeNull();
-          expect(getByText(table1Row, `Report: ${scoreText}`)).not.toBeNull();
-        });
-      });
+            expect(reportScore).toHaveBeenCalledOnce();
+            expect(loadPairings).toHaveBeenCalledTimes(2);
+            expect(
+              queryByRole(table1Row, "button", { name: /report pairing/i }),
+            ).toBeNull();
+            expect(
+              getByText(table1Row, `Report: ${scoreReport.label ?? ""}`),
+            ).not.toBeNull();
+          });
+        },
+      );
     });
   });
 });

--- a/app/frontend/tests/RoundsTestData.ts
+++ b/app/frontend/tests/RoundsTestData.ts
@@ -148,14 +148,50 @@ export const MockPairingsData: PairingsData = {
   stages: [MockSwissStage],
 };
 
-export const MockSelfReport: ScoreReport = {
+export const MockSelfReportPlayer1Sweep: ScoreReport = {
   report_player_id: 1,
   score1: 6,
   score2: 0,
   intentional_draw: false,
   label: "6 - 0",
-  score1_corp: null,
+  score1_corp: 3,
   score2_corp: null,
+  score1_runner: 3,
+  score2_runner: null,
+};
+
+export const MockSelfReportCorpSplit: ScoreReport = {
+  report_player_id: 1,
+  score1: 3,
+  score2: 3,
+  intentional_draw: false,
+  label: "3 - 3 (C)",
+  score1_corp: 3,
+  score2_corp: 3,
   score1_runner: null,
   score2_runner: null,
+};
+
+export const MockSelfReportRunnerSplit: ScoreReport = {
+  report_player_id: 1,
+  score1: 3,
+  score2: 3,
+  intentional_draw: false,
+  label: "3 - 3 (R)",
+  score1_corp: null,
+  score2_corp: null,
+  score1_runner: 3,
+  score2_runner: 3,
+};
+
+export const MockSelfReportPlayer2Sweep: ScoreReport = {
+  report_player_id: 1,
+  score1: 0,
+  score2: 6,
+  intentional_draw: false,
+  label: "0 - 6",
+  score1_corp: null,
+  score2_corp: 3,
+  score1_runner: null,
+  score2_runner: 3,
 };


### PR DESCRIPTION
Player reports for double-sided pairings are displaying the opposite scores on the Pairings tab for regular players. That display is now generated the same way as it is for the TO, using the `readableScoreReport()` function. This is also done client-side so the code that was appending extra data to pairings can be removed.

I cleaned up (and fixed...) the tests for this by creating fully populated mock objects that can be used by `readableScoreReport()`.