### PR TITLE
Svelte conversion - deck registration finishing touches

### DIFF
--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -17,17 +17,25 @@
     value: Printing;
   }
 
+  interface CardDiff {
+    title: string;
+    delta: number;
+  }
+
   let {
     deck = $bindable(),
+    originalDeck,
     isCorp,
     editMode,
   }: {
     deck?: Deck;
+    originalDeck: Deck;
     isCorp: boolean;
     editMode: boolean;
   } = $props();
 
-  let selectedCard = $state<Printing | null>();
+  let selectedCard = $state<Printing | null>(null);
+  let cardDiffs = $state<CardDiff[]>([]);
   let cardTotal = $derived.by(() => {
     if (!deck) {
       return 0;
@@ -53,6 +61,43 @@
 
   function adjustFactionId(factionId: string) {
     return factionId.replace("_", "-");
+  }
+
+  function diffDecks() {
+    cardDiffs = [];
+
+    if (!deck) {
+      return;
+    }
+    
+    // Removed cards and quantity changes
+    originalDeck.cards.forEach((originalCard) => {
+      const card = deck.cards.find((c) => c.nrdb_card_id === originalCard.nrdb_card_id);
+      if (card) {
+        if (card.quantity !== originalCard.quantity) {
+          cardDiffs.push({
+            title: originalCard.title,
+            delta: card.quantity - originalCard.quantity,
+          });
+        }
+      } else {
+        cardDiffs.push({
+          title: originalCard.title,
+          delta: -originalCard.quantity,
+        });
+      }
+    });
+
+    // Added cards
+    deck.cards.forEach((card) => {
+      const originalCard = originalDeck.cards.find((c) => c.nrdb_card_id === card.nrdb_card_id);
+      if (!originalCard) {
+        cardDiffs.push({
+          title: card.title,
+          delta: card.quantity,
+        });
+      }
+    });
   }
 
   async function copyToClipboard() {
@@ -118,6 +163,8 @@
       faction_id: printing.attributes.faction_id,
       influence_cost: printing.attributes.influence_cost ?? 0,
     });
+
+    diffDecks();
   }
 
   function addCard(selection: CardSearchOption | null) {
@@ -143,6 +190,8 @@
     }
 
     selectedCard = null;
+
+    diffDecks();
   }
 
   function transformCardLookup(response: PrintingsResponse) {
@@ -161,6 +210,8 @@
         deck.cards.splice(i, 1);
       }
     }
+
+    diffDecks();
   }
 </script>
 
@@ -371,4 +422,30 @@
       </tr>
     </tbody>
   </table>
+
+  <!-- Editing diffs -->
+  {#if editMode}
+    <table class="table table-bordered table-striped">
+      <thead class="thead-dark">
+        <tr>
+          <th class="text-center">Changes</th>
+          <th class="text-center deck-side-column">Qty</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#if cardDiffs.length === 0}
+          <tr>
+            <td colspan="2">No changes</td>
+          </tr>
+        {:else}
+          {#each cardDiffs as diff (diff.title)}
+            <tr>
+              <td>{diff.title}</td>
+              <td class="text-center align-middle">{diff.delta > 0 ? "+" : ""}{diff.delta}</td>
+            </tr>
+          {/each}
+        {/if}
+      </tbody>
+    </table>
+  {/if}
 {/if}

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
   import Svelecte from "svelecte";
   import Identity from "../identities/Identity.svelte";
-  import {
-    deckCsv,
-    type Card,
-    type Deck,
-  } from "../utils/decks.svelte";
+  import { deckCsv, type Card, type Deck } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
@@ -85,10 +81,12 @@
         });
       }
     }
-    
+
     // Removed cards and quantity changes
     originalDeck.cards.forEach((originalCard) => {
-      const card = deck.cards.find((c) => c.nrdb_card_id === originalCard.nrdb_card_id);
+      const card = deck.cards.find(
+        (c) => c.nrdb_card_id === originalCard.nrdb_card_id,
+      );
       if (card) {
         if (card.quantity !== originalCard.quantity) {
           cardDiffs.push({
@@ -106,7 +104,9 @@
 
     // Added cards
     deck.cards.forEach((card) => {
-      const originalCard = originalDeck.cards.find((c) => c.nrdb_card_id === card.nrdb_card_id);
+      const originalCard = originalDeck.cards.find(
+        (c) => c.nrdb_card_id === card.nrdb_card_id,
+      );
       if (!originalCard) {
         cardDiffs.push({
           title: card.title,
@@ -155,13 +155,15 @@
 
     diffDecks();
   }
-  
+
   function changeCard(cardPrintingId: string | null, printing: Printing) {
     if (!cardPrintingId || !deck || !printing.id) {
       return;
     }
 
-    const i = deck.cards.findIndex((c) => c.nrdb_printing_id === cardPrintingId);
+    const i = deck.cards.findIndex(
+      (c) => c.nrdb_printing_id === cardPrintingId,
+    );
     if (i < 0 || i >= deck.cards.length) {
       return;
     }
@@ -213,7 +215,9 @@
   }
 
   function transformCardLookup(response: PrintingsResponse) {
-    return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
+    return response.data.map((p) => {
+      return { label: p.attributes.title, value: p };
+    });
   }
 
   function changeQuantity(card: Card, delta: number) {
@@ -222,7 +226,7 @@
     }
 
     card.quantity += delta;
-    card.influence = card.influence_cost * card.quantity
+    card.influence = card.influence_cost * card.quantity;
     if (card.quantity === 0) {
       const i = deck.cards.indexOf(card);
       if (i !== -1) {
@@ -388,7 +392,9 @@
               sideId={deck.details.side_id ?? ""}
               isIdentity={false}
               allowEdit={editMode}
-              onChange={(p: Printing) => { changeCard(card.nrdb_printing_id, p); }}
+              onChange={(p: Printing) => {
+                changeCard(card.nrdb_printing_id, p);
+              }}
             >
               <img
                 src={getCardTypeImage(card.card_type_id)}
@@ -463,7 +469,9 @@
           {#each cardDiffs as diff (diff.title)}
             <tr>
               <td>{diff.title}</td>
-              <td class="text-center align-middle">{diff.delta > 0 ? "+" : ""}{diff.delta}</td>
+              <td class="text-center align-middle">
+                {diff.delta > 0 ? "+" : ""}{diff.delta}
+              </td>
             </tr>
           {/each}
         {/if}

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -5,7 +5,6 @@
     deckCsv,
     type Card,
     type Deck,
-    sortCards,
   } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
@@ -27,12 +26,6 @@
     isCorp: boolean;
     editMode: boolean;
   } = $props();
-
-  $effect(() => {
-    if (deck) {
-      sortCards(deck.cards);
-    }
-  });
 
   let selectedCard = $state<Printing | null>();
   let cardTotal = $derived.by(() => {

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
+  import Svelecte from "svelecte";
   import Identity from "../identities/Identity.svelte";
   import {
     deckCsv,
     type Card,
     type Deck,
-    loadPrintings,
     sortCards,
   } from "../utils/decks.svelte";
   import { downloadBlob } from "../utils/files";
   import { getCardTypeImage } from "../utils/images";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+  import type { Printing, PrintingsResponse } from "../lib/api_types";
+  import EditableCard from "./EditableCard.svelte";
+
+  interface CardSearchOption {
+    label: string;
+    value: Printing;
+  }
 
   let {
     deck = $bindable(),
@@ -27,6 +34,7 @@
     }
   });
 
+  let selectedCard = $state<Printing | null>();
   let cardTotal = $derived.by(() => {
     if (!deck) {
       return 0;
@@ -45,6 +53,10 @@
       .filter((card: Card) => card.faction_id !== deck.details.faction_id)
       .reduce((total: number, card: Card) => total + card.influence, 0);
   });
+
+  function getCardSearchUrl(sideId: string | null) {
+    return `https://api.netrunnerdb.com/api/v3/public/printings?fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost&filter[side_id]=${sideId}&filter[search]=[query]&filter[distinct_cards]=true`;
+  }
 
   function adjustFactionId(factionId: string) {
     return factionId.replace("_", "-");
@@ -75,115 +87,73 @@
     );
   }
 
-  async function searchCard(name: string, cardType?: string) {
-    if (!deck || !name) {
-      return null;
+  function changeIdentity(printing: Printing) {
+    if (!deck || !printing.id) {
+      return;
     }
 
-    let queryString = `filter[side_id]=${deck.details.side_id}&filter[search]=${name}&filter[distinct_cards]=true&page[size]=1`;
-    if (cardType) {
-      queryString += `filter[card_type_id]=${cardType}`;
-    }
-
-    const printings = await loadPrintings(queryString);
-    return !printings ||
-      (printings.meta?.stats?.total?.count &&
-        printings.meta.stats.total.count !== 1)
-      ? null
-      : printings;
+    deck.details.identity_nrdb_printing_id = printing.id;
+    deck.details.identity_nrdb_card_id = printing.attributes.card_id;
+    deck.details.identity_title = printing.attributes.title;
+    deck.details.faction_id = printing.attributes.faction_id;
+    deck.details.min_deck_size = printing.attributes.minimum_deck_size;
+    deck.details.max_influence = printing.attributes.influence_limit;
   }
-
-  async function identityNameChanged(event: {
-    currentTarget: HTMLInputElement;
-  }) {
-    const currentTarget = event.currentTarget;
-
-    if (!deck) {
-      setInputValidity(currentTarget, false);
+  
+  function changeCard(cardPrintingId: string | null, printing: Printing) {
+    if (!cardPrintingId || !deck || !printing.id) {
       return;
     }
 
-    const printings = await searchCard(
-      currentTarget.value,
-      `${deck.details.side_id}_identity`,
-    );
-    if (!printings) {
-      setInputValidity(currentTarget, false);
-      return;
-    }
-
-    deck.details.identity_nrdb_printing_id = printings.data[0].id;
-    deck.details.identity_nrdb_card_id = printings.data[0].attributes.card_id;
-    deck.details.identity_title = printings.data[0].attributes.title;
-    deck.details.faction_id = printings.data[0].attributes.faction_id;
-    deck.details.min_deck_size = printings.data[0].attributes.minimum_deck_size;
-    deck.details.max_influence = printings.data[0].attributes.influence_limit;
-    setInputValidity(currentTarget, true);
-  }
-
-  async function cardNameChanged(
-    event: { currentTarget: HTMLInputElement },
-    card: Card,
-  ) {
-    const currentTarget = event.currentTarget;
-    const printings = await searchCard(currentTarget.value);
-    if (!deck || !printings) {
-      setInputValidity(currentTarget, false);
-      return;
-    }
-
-    const i = deck.cards.indexOf(card);
-    if (i === -1) {
-      setInputValidity(currentTarget, false);
+    const i = deck.cards.findIndex((c) => c.nrdb_printing_id === cardPrintingId);
+    if (i < 0 || i >= deck.cards.length) {
       return;
     }
 
     deck.cards.splice(i, 1, {
-      id: card.id,
-      deck_id: card.deck_id,
-      title: printings.data[0].attributes.title,
-      quantity: card.quantity,
+      id: deck.cards[i].id,
+      deck_id: deck.cards[i].deck_id,
+      title: printing.attributes.title,
+      quantity: deck.cards[i].quantity,
       influence:
-        (printings.data[0].attributes.influence_cost ?? 0) * card.quantity,
-      nrdb_card_id: printings.data[0].attributes.card_id,
+        (printing.attributes.influence_cost ?? 0) * deck.cards[i].quantity,
+      nrdb_card_id: printing.attributes.card_id,
       created_at: "",
       updated_at: "",
-      nrdb_printing_id: card.nrdb_printing_id,
-      card_type_id: printings.data[0].attributes.card_type_id,
-      faction_id: printings.data[0].attributes.faction_id,
-      influence_cost: printings.data[0].attributes.influence_cost ?? 0,
+      nrdb_printing_id: deck.cards[i].nrdb_printing_id,
+      card_type_id: printing.attributes.card_type_id,
+      faction_id: printing.attributes.faction_id,
+      influence_cost: printing.attributes.influence_cost ?? 0,
     });
-    setInputValidity(currentTarget, true);
   }
 
-  async function addCard(event: { currentTarget: HTMLInputElement }) {
-    const currentTarget = event.currentTarget;
-    const printings = await searchCard(currentTarget.value);
-    if (!deck || !printings) {
-      setInputValidity(currentTarget, false);
+  function addCard(selection: CardSearchOption | null) {
+    if (!deck || !selection?.value.id) {
       return;
     }
 
-    // Add the card to the deck if it doesn't already exist
-    if (!deck.cards.find((c) => c.nrdb_printing_id === printings.data[0].id)) {
+    if (!deck.cards.find((c) => c.nrdb_printing_id === selection.value.id)) {
       deck.cards.push({
         id: 0,
         deck_id: deck.details.id,
-        title: printings.data[0].attributes.title,
+        title: selection.value.attributes.title,
         quantity: 1,
-        influence: printings.data[0].attributes.influence_cost ?? 0,
-        nrdb_card_id: printings.data[0].attributes.card_id,
+        influence: selection.value.attributes.influence_cost ?? 0,
+        nrdb_card_id: selection.value.attributes.card_id,
         created_at: "",
         updated_at: "",
-        nrdb_printing_id: printings.data[0].id,
-        card_type_id: printings.data[0].attributes.card_type_id,
-        faction_id: printings.data[0].attributes.faction_id,
-        influence_cost: printings.data[0].attributes.influence_cost ?? 0,
+        nrdb_printing_id: selection.value.id,
+        card_type_id: selection.value.attributes.card_type_id,
+        faction_id: selection.value.attributes.faction_id,
+        influence_cost: selection.value.attributes.influence_cost ?? 0,
       });
     }
 
-    currentTarget.classList.remove("is-valid", "is-invalid");
-    currentTarget.value = "";
+    selectedCard = null;
+  }
+
+  function transformCardLookup(response: PrintingsResponse) {
+    return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
   }
 
   function changeQuantity(card: Card, delta: number) {
@@ -198,11 +168,6 @@
         deck.cards.splice(i, 1);
       }
     }
-  }
-
-  function setInputValidity(input: HTMLInputElement, valid: boolean) {
-    input.classList.remove("is-valid", "is-invalid");
-    input.classList.add(valid ? "is-valid" : "is-invalid");
   }
 </script>
 
@@ -293,24 +258,19 @@
       <tr data-testid="identity_row">
         <td class="text-center align-middle">{deck.details.min_deck_size}</td>
         <td>
-          {#if editMode}
-            <input
-              type="text"
-              placeholder="Enter identity name"
-              class="form-control"
-              value={deck.details.identity_title}
-              onchange={async (e) => {
-                await identityNameChanged(e);
-              }}
-            />
-          {:else}
+          <EditableCard
+            sideId={deck.details.side_id ?? ""}
+            isIdentity={true}
+            allowEdit={editMode}
+            onChange={changeIdentity}
+          >
             <Identity
               identity={{
                 name: deck.details.identity_title ?? "",
                 faction: adjustFactionId(deck.details.faction_id ?? ""),
               }}
             />
-          {/if}
+          </EditableCard>
         </td>
         <td class="text-center align-middle">{deck.details.max_influence}</td>
       </tr>
@@ -361,17 +321,12 @@
             {/if}
           </td>
           <td>
-            {#if editMode}
-              <input
-                type="text"
-                placeholder="Enter card name"
-                class="form-control"
-                value={card.title}
-                onchange={async (e) => {
-                  await cardNameChanged(e, card);
-                }}
-              />
-            {:else}
+            <EditableCard
+              sideId={deck.details.side_id ?? ""}
+              isIdentity={false}
+              allowEdit={editMode}
+              onChange={(p: Printing) => { changeCard(card.nrdb_printing_id, p); }}
+            >
               <img
                 src={getCardTypeImage(card.card_type_id)}
                 alt={card.card_type_id}
@@ -382,7 +337,7 @@
                 )} {adjustFactionId(card.faction_id)}"
               ></i>
               {card.title}
-            {/if}
+            </EditableCard>
           </td>
           <td class="text-center align-middle">
             {#if card.influence_cost && card.faction_id != deck.details.faction_id}
@@ -395,14 +350,15 @@
         <tr data-testid="new_card_row">
           <td></td>
           <td>
-            <input
-              id="name"
-              type="text"
+            <Svelecte
+              controlClass="form-control"
               placeholder="Enter card name"
-              class="form-control"
-              onchange={async (e) => {
-                await addCard(e);
-              }}
+              fetch={getCardSearchUrl(deck.details.side_id)}
+              fetchCallback={transformCardLookup}
+              labelField="label"
+              valueField="value"
+              bind:value={selectedCard}
+              onChange={addCard}
             />
           </td>
           <td></td>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -69,6 +69,22 @@
     if (!deck) {
       return;
     }
+
+    // Identity
+    if (originalDeck.details.identity_title !== deck.details.identity_title) {
+      if (originalDeck.details.identity_title) {
+        cardDiffs.push({
+          title: originalDeck.details.identity_title,
+          delta: -1,
+        });
+      }
+      if (deck.details.identity_title) {
+        cardDiffs.push({
+          title: deck.details.identity_title,
+          delta: 1,
+        });
+      }
+    }
     
     // Removed cards and quantity changes
     originalDeck.cards.forEach((originalCard) => {
@@ -136,6 +152,8 @@
     deck.details.faction_id = printing.attributes.faction_id;
     deck.details.min_deck_size = printing.attributes.minimum_deck_size;
     deck.details.max_influence = printing.attributes.influence_limit;
+
+    diffDecks();
   }
   
   function changeCard(cardPrintingId: string | null, printing: Printing) {
@@ -426,7 +444,10 @@
 
   <!-- Editing diffs -->
   {#if editMode}
-    <table class="table table-bordered table-striped">
+    <table
+      class="table table-bordered table-striped"
+      aria-label={isCorp ? "corp deck changes" : "runner deck changes"}
+    >
       <thead class="thead-dark">
         <tr>
           <th class="text-center">Changes</th>

--- a/app/frontend/players/DeckDisplay.svelte
+++ b/app/frontend/players/DeckDisplay.svelte
@@ -204,6 +204,7 @@
     }
 
     card.quantity += delta;
+    card.influence = card.influence_cost * card.quantity
     if (card.quantity === 0) {
       const i = deck.cards.indexOf(card);
       if (i !== -1) {

--- a/app/frontend/players/EditableCard.svelte
+++ b/app/frontend/players/EditableCard.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
   import Svelecte from "svelecte";
-  import type { Printing, PrintingsResponse } from "../lib/api_types";
+  import type { Printing } from "../lib/api_types";
   import type { Snippet } from "svelte";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
-
-  interface CardSearchOption {
-    label: string;
-    value: Printing;
-  }
+  import { transformCardLookup, type CardSearchOption } from "../utils/decks.svelte";
 
   let {
     sideId,
@@ -28,10 +24,6 @@
   function getCardSearchUrl(sideId: string | null) {
     const searchString = `[query] ${isIdentity ? "t:identity" : "t!identity"}`;
     return `https://api.netrunnerdb.com/api/v3/public/printings?fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost&filter[side_id]=${sideId}&filter[distinct_cards]=true&filter[search]=${searchString}`;
-  }
-
-  function transformCardLookup(response: PrintingsResponse) {
-    return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
   }
 
   function sveleteOnChange(selection: CardSearchOption | null) {
@@ -58,7 +50,7 @@
     />
     <button
       type="button"
-      title="Add"
+      title="Cancel"
       class="btn btn-link p-0 ml-2"
       onclick={() => editing = false}
     >
@@ -71,7 +63,7 @@
     {#if allowEdit}
       <button
         type="button"
-        title="Add"
+        title="Edit"
         class="btn btn-link p-0 ml-2"
         onclick={() => editing = true}
       >

--- a/app/frontend/players/EditableCard.svelte
+++ b/app/frontend/players/EditableCard.svelte
@@ -3,14 +3,17 @@
   import type { Printing } from "../lib/api_types";
   import type { Snippet } from "svelte";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
-  import { transformCardLookup, type CardSearchOption } from "../utils/decks.svelte";
+  import {
+    transformCardLookup,
+    type CardSearchOption,
+  } from "../utils/decks.svelte";
 
   let {
     sideId,
     allowEdit,
     isIdentity,
     onChange,
-    children
+    children,
   }: {
     sideId: string;
     allowEdit: boolean;
@@ -52,7 +55,7 @@
       type="button"
       title="Cancel"
       class="btn btn-link p-0 ml-2"
-      onclick={() => editing = false}
+      onclick={() => (editing = false)}
     >
       <FontAwesomeIcon icon="close" />
     </button>
@@ -65,7 +68,7 @@
         type="button"
         title="Edit"
         class="btn btn-link p-0 ml-2"
-        onclick={() => editing = true}
+        onclick={() => (editing = true)}
       >
         <FontAwesomeIcon icon="pencil" />
       </button>

--- a/app/frontend/players/EditableCard.svelte
+++ b/app/frontend/players/EditableCard.svelte
@@ -45,16 +45,8 @@
   }
 </script>
 
-{#if editing}
-  <button
-    type="button"
-    title="Add"
-    class="btn btn-link p-0 float-right"
-    onclick={() => editing = false}
-  >
-    <FontAwesomeIcon icon="close" />
-  </button>
-  <div>
+<div class="d-flex">
+  {#if editing}
     <Svelecte
       controlClass="form-control"
       placeholder="Enter identity name"
@@ -64,20 +56,27 @@
       valueField="value"
       onChange={sveleteOnChange}
     />
-  </div>
-{:else}
-  <div>
+    <button
+      type="button"
+      title="Add"
+      class="btn btn-link p-0 ml-2"
+      onclick={() => editing = false}
+    >
+      <FontAwesomeIcon icon="close" />
+    </button>
+  {:else}
+    <div class="w-100">
+      {@render children()}
+    </div>
     {#if allowEdit}
       <button
         type="button"
         title="Add"
-        class="btn btn-link p-0 float-right"
+        class="btn btn-link p-0 ml-2"
         onclick={() => editing = true}
       >
         <FontAwesomeIcon icon="pencil" />
       </button>
     {/if}
-
-    {@render children()}
-  </div>
-{/if}
+  {/if}
+</div>

--- a/app/frontend/players/EditableCard.svelte
+++ b/app/frontend/players/EditableCard.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import Svelecte from "svelecte";
+  import type { Printing, PrintingsResponse } from "../lib/api_types";
+  import type { Snippet } from "svelte";
+  import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
+
+  interface CardSearchOption {
+    label: string;
+    value: Printing;
+  }
+
+  let {
+    sideId,
+    allowEdit,
+    isIdentity,
+    onChange,
+    children
+  }: {
+    sideId: string;
+    allowEdit: boolean;
+    isIdentity: boolean;
+    onChange: (printing: Printing) => void;
+    children: Snippet;
+  } = $props();
+
+  let editing = $state(false);
+
+  function getCardSearchUrl(sideId: string | null) {
+    const searchString = `[query] ${isIdentity ? "t:identity" : "t!identity"}`;
+    return `https://api.netrunnerdb.com/api/v3/public/printings?fields[printings]=card_id,card_type_id,title,side_id,faction_id,minimum_deck_size,influence_limit,influence_cost&filter[side_id]=${sideId}&filter[distinct_cards]=true&filter[search]=${searchString}`;
+  }
+
+  function transformCardLookup(response: PrintingsResponse) {
+    return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
+  }
+
+  function sveleteOnChange(selection: CardSearchOption | null) {
+    if (!selection?.value.id) {
+      return;
+    }
+
+    onChange(selection.value);
+
+    editing = false;
+  }
+</script>
+
+{#if editing}
+  <button
+    type="button"
+    title="Add"
+    class="btn btn-link p-0 float-right"
+    onclick={() => editing = false}
+  >
+    <FontAwesomeIcon icon="close" />
+  </button>
+  <div>
+    <Svelecte
+      controlClass="form-control"
+      placeholder="Enter identity name"
+      fetch={getCardSearchUrl(sideId)}
+      fetchCallback={transformCardLookup}
+      labelField="label"
+      valueField="value"
+      onChange={sveleteOnChange}
+    />
+  </div>
+{:else}
+  <div>
+    {#if allowEdit}
+      <button
+        type="button"
+        title="Add"
+        class="btn btn-link p-0 float-right"
+        onclick={() => editing = true}
+      >
+        <FontAwesomeIcon icon="pencil" />
+      </button>
+    {/if}
+
+    {@render children()}
+  </div>
+{/if}

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -13,6 +13,7 @@
     Deck,
     convertNrdbDeck,
     getPrintings,
+    sortCards,
   } from "../utils/decks.svelte";
   import { loadDecks, savePlayer } from "../players/PlayersData";
   import DeckDisplay from "./DeckDisplay.svelte";
@@ -82,7 +83,9 @@
 
   function resetEditDecks() {
     corpDeck = $state.snapshot(originalCorpDeck);
+    sortCards(corpDeck.cards);
     runnerDeck = $state.snapshot(originalRunnerDeck);
+    sortCards(runnerDeck.cards);
   }
 
   async function save() {

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -160,12 +160,12 @@
   </button>
 {/snippet}
 
-{#snippet decksList(isCorp: boolean, selectedDeck: Deck | null)}
+{#snippet decksList(isCorp: boolean, selectedDeck: Deck)}
   {#if decks !== null}
     <ul class="list-group list-group-flush" style="border-bottom: 0;">
       <li class="list-group-item selected-deck">
-        <div class="selected-deck-buttons">
-          {#if selectedDeck}
+        {#if selectedDeck.details.nrdb_uuid}
+          <div class="selected-deck-buttons">
             <button
               type="button"
               title="Deselect"
@@ -176,9 +176,7 @@
             >
               <FontAwesomeIcon icon="close" />
             </button>
-          {/if}
-        </div>
-        {#if selectedDeck}
+          </div>
           <div
             class="selected-deck-identity"
             style={`background-image:url(https://card-images.netrunnerdb.com/v2/small/${selectedDeck.details.identity_nrdb_printing_id}.jpg)`}

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -116,7 +116,10 @@
     );
 
     await loadTournamentDecks();
-    toggleEditing();
+
+    if (editing) {
+      toggleEditing();
+    }
 
     return true;
   }

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -373,12 +373,25 @@
   <!-- Deck display -->
   <div class="row">
     <div class="col-md-6">
-      <DeckDisplay bind:deck={corpDeck} isCorp={true} editMode={editing} />
+      <DeckDisplay bind:deck={corpDeck} originalDeck={originalCorpDeck} isCorp={true} editMode={editing} />
     </div>
 
     <div class="col-md-6">
-      <DeckDisplay bind:deck={runnerDeck} isCorp={false} editMode={editing} />
+      <DeckDisplay bind:deck={runnerDeck} originalDeck={originalRunnerDeck} isCorp={false} editMode={editing} />
     </div>
+
+    {#if editing}
+      <div class="col-md-12">
+        <ProgressButton
+          css="btn btn-success float-right"
+          inProgressText="Saving"
+          completeText="Saved"
+          onclick={save}
+        >
+          <FontAwesomeIcon icon="floppy-o" /> Save
+        </ProgressButton>
+      </div>
+    {/if}
   </div>
 {:else}
   <div class="d-flex align-items-center m-2">

--- a/app/frontend/players/Registration.svelte
+++ b/app/frontend/players/Registration.svelte
@@ -373,11 +373,21 @@
   <!-- Deck display -->
   <div class="row">
     <div class="col-md-6">
-      <DeckDisplay bind:deck={corpDeck} originalDeck={originalCorpDeck} isCorp={true} editMode={editing} />
+      <DeckDisplay
+        bind:deck={corpDeck}
+        originalDeck={originalCorpDeck}
+        isCorp={true}
+        editMode={editing}
+      />
     </div>
 
     <div class="col-md-6">
-      <DeckDisplay bind:deck={runnerDeck} originalDeck={originalRunnerDeck} isCorp={false} editMode={editing} />
+      <DeckDisplay
+        bind:deck={runnerDeck}
+        originalDeck={originalRunnerDeck}
+        isCorp={false}
+        editMode={editing}
+      />
     </div>
 
     {#if editing}

--- a/app/frontend/players/RegistrationCard.svelte
+++ b/app/frontend/players/RegistrationCard.svelte
@@ -9,6 +9,7 @@
     type IdentityNames,
   } from "../identities/Identity";
   import { onMount } from "svelte";
+    import ProgressButton from "../widgets/ProgressButton.svelte";
 
   let {
     userId,
@@ -34,6 +35,12 @@
   async function savePlayer() {
     playerEdit = await savePlayerRequest(tournament.id, playerEdit);
     readOnly = true;
+
+    if (tournament.nrdb_deck_registration) {
+      window.location.href = `/beta/tournaments/${tournament.id}/registration`;
+    }
+
+    return true;
   }
 </script>
 
@@ -246,10 +253,11 @@
     </div>
 
     <div class="text-right">
-      <button
-        type="button"
-        class="btn btn-primary"
+      <ProgressButton
+        css="btn btn-primary"
         disabled={playerEdit.id === 0 && !playerAgreed}
+        inProgressText="Registering player"
+        completeText="Registered player"
         onclick={savePlayer}
       >
         <FontAwesomeIcon icon="user-plus" />
@@ -260,7 +268,7 @@
         {:else}
           Register
         {/if}
-      </button>
+      </ProgressButton>
     </div>
   </div>
 {/if}

--- a/app/frontend/players/RegistrationCard.svelte
+++ b/app/frontend/players/RegistrationCard.svelte
@@ -9,7 +9,7 @@
     type IdentityNames,
   } from "../identities/Identity";
   import { onMount } from "svelte";
-    import ProgressButton from "../widgets/ProgressButton.svelte";
+  import ProgressButton from "../widgets/ProgressButton.svelte";
 
   let {
     userId,

--- a/app/frontend/tests/Registration.svelte-test.ts
+++ b/app/frontend/tests/Registration.svelte-test.ts
@@ -8,12 +8,12 @@ import {
 } from "./PlayersTestData";
 import userEvent from "@testing-library/user-event";
 import {
-  fireEvent,
-  getByDisplayValue,
   getByLabelText,
   getByRole,
   getByTestId,
+  getByText,
   queryByDisplayValue,
+  queryByText,
   render,
   screen,
   waitFor,
@@ -23,7 +23,7 @@ import { loadDecks, loadPlayer, savePlayer } from "../players/PlayersData";
 import { Identity } from "../identities/Identity";
 import {
   getPrintings,
-  loadPrintings,
+  transformCardLookup,
   type NrdbDeck,
 } from "../utils/decks.svelte";
 import type { Printing } from "../lib/api_types";
@@ -44,9 +44,7 @@ vi.mock("../utils/decks.svelte", async (importOriginal) => {
   return {
     ...(await importOriginal<typeof import("../utils/decks.svelte")>()),
     getPrintings: vi.fn(() => MockPrintings),
-    loadPrintings: vi.fn(() => {
-      return { data: Array.from(MockPrintings.values()) };
-    }),
+    transformCardLookup: vi.fn(() => []),
   };
 });
 
@@ -175,6 +173,18 @@ describe("Registration", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
   });
 
   describe("no existing decks", () => {
@@ -338,20 +348,21 @@ describe("Registration", () => {
           ),
         );
 
-        const runnerDeckTable = screen.getByLabelText("runner deck list");
-
-        vi.mocked(loadPrintings).mockImplementation(() =>
-          Promise.resolve({ data: [MockBetaBuildPrinting] }),
+        vi.mocked(transformCardLookup).mockImplementation(() =>
+          [{ label: MockBetaBuildPrinting.attributes.title, value: MockBetaBuildPrinting }]
         );
 
-        const newCardRow = getByTestId(runnerDeckTable, "new_card_row");
-        await fireEvent.change(getByRole(newCardRow, "textbox"), {
-          target: { value: "beta bui" },
-        });
+        const runnerDeckTable = screen.getByLabelText("runner deck list");
 
-        expect(loadPrintings).toHaveBeenCalledOnce();
+        const newCardRow = getByTestId(runnerDeckTable, "new_card_row");
+        await user.type(getByRole(newCardRow, "textbox"), "beta");
+        await waitFor(() => {
+          expect(getByText(newCardRow, "Build")).toBeInTheDocument()
+        });
+        await user.keyboard("{Enter}");
+
         expect(
-          getByDisplayValue(
+          getByText(
             runnerDeckTable,
             MockBetaBuildPrinting.attributes.title,
           ),
@@ -368,31 +379,35 @@ describe("Registration", () => {
           ),
         );
 
-        const runnerDeckTable = screen.getByLabelText("runner deck list");
-
-        vi.mocked(loadPrintings).mockImplementation(() =>
-          Promise.resolve({ data: [MockBetaBuildPrinting] }),
+        vi.mocked(transformCardLookup).mockImplementation(() =>
+          [{ label: MockBetaBuildPrinting.attributes.title, value: MockBetaBuildPrinting }]
         );
 
-        const cardRow = getByTestId(
-          runnerDeckTable,
+        let cardRow = getByTestId(
+          screen.getByLabelText("runner deck list"),
           `card_${MockSureGamblePrinting.attributes.card_id}_row`,
         );
-        await fireEvent.change(getByRole(cardRow, "textbox"), {
-          target: { value: "beta bui" },
+
+        await user.click(getByRole(cardRow, "button", { name: "Edit" }));
+        expect(
+          getByRole(cardRow, "button", { name: "Cancel" }),
+        ).toBeInTheDocument();
+        await user.type(getByRole(cardRow, "textbox"), "beta");
+        await waitFor(() => {
+          expect(getByText(cardRow, "Build")).toBeInTheDocument();
         });
+        await user.keyboard("{Enter}");
+        cardRow = getByTestId(
+          screen.getByLabelText("runner deck list"),
+          `card_${MockBetaBuildPrinting.attributes.card_id}_row`,
+        );
+        await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
 
         expect(
-          queryByDisplayValue(
-            runnerDeckTable,
-            MockBetaBuildPrinting.attributes.title,
-          ),
+          queryByText(cardRow, MockBetaBuildPrinting.attributes.title),
         ).toBeInTheDocument();
         expect(
-          queryByDisplayValue(
-            runnerDeckTable,
-            MockSureGamblePrinting.attributes.title,
-          ),
+          queryByText(cardRow, MockSureGamblePrinting.attributes.title),
         ).not.toBeInTheDocument();
       });
 
@@ -455,25 +470,28 @@ describe("Registration", () => {
           ),
         );
 
-        const runnerIdTable = screen.getByLabelText("runner deck ID");
-
-        vi.mocked(loadPrintings).mockImplementation(() =>
-          Promise.resolve({ data: [MockZahyaPrinting] }),
+        vi.mocked(transformCardLookup).mockImplementation(() =>
+          [{ label: MockZahyaPrinting.attributes.title, value: MockZahyaPrinting }]
         );
 
-        const cardRow = getByTestId(runnerIdTable, `identity_row`);
-        await fireEvent.change(getByRole(cardRow, "textbox"), {
-          target: { value: "zahya" },
+        const cardRow = getByTestId(screen.getByLabelText("runner deck ID"), `identity_row`);
+
+        await user.click(getByRole(cardRow, "button", { name: "Edit" }));
+        expect(
+          getByRole(cardRow, "button", { name: "Cancel" }),
+        ).toBeInTheDocument();
+        await user.type(getByRole(cardRow, "textbox"), "zahya");
+        await waitFor(() => {
+          expect(getByText(cardRow, "Sadeghi: Versatile Smuggler")).toBeInTheDocument()
         });
+        await user.keyboard("{Enter}");
+        await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
 
         expect(
-          queryByDisplayValue(
-            runnerIdTable,
-            MockZahyaPrinting.attributes.title,
-          ),
+          queryByText(cardRow, MockZahyaPrinting.attributes.title),
         ).toBeInTheDocument();
         expect(
-          queryByDisplayValue(runnerIdTable, MockBazPrinting.attributes.title),
+          queryByText(cardRow, MockBazPrinting.attributes.title),
         ).not.toBeInTheDocument();
       });
     });

--- a/app/frontend/tests/Registration.svelte-test.ts
+++ b/app/frontend/tests/Registration.svelte-test.ts
@@ -354,6 +354,7 @@ describe("Registration", () => {
 
         const runnerDeckTable = screen.getByLabelText("runner deck list");
 
+        // Add card
         const newCardRow = getByTestId(runnerDeckTable, "new_card_row");
         await user.type(getByRole(newCardRow, "textbox"), "beta");
         await waitFor(() => {
@@ -361,6 +362,7 @@ describe("Registration", () => {
         });
         await user.keyboard("{Enter}");
 
+        // Validate new card
         expect(
           getByText(
             runnerDeckTable,
@@ -368,6 +370,9 @@ describe("Registration", () => {
           ),
         ).toBeInTheDocument();
         expect((newCardRow as HTMLInputElement).value).toBeUndefined();
+
+        // Validate diff
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockBetaBuildPrinting.attributes.title}+1`);
       });
 
       it("change a card", async () => {
@@ -388,6 +393,7 @@ describe("Registration", () => {
           `card_${MockSureGamblePrinting.attributes.card_id}_row`,
         );
 
+        // Change card
         await user.click(getByRole(cardRow, "button", { name: "Edit" }));
         expect(
           getByRole(cardRow, "button", { name: "Cancel" }),
@@ -403,12 +409,16 @@ describe("Registration", () => {
         );
         await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
 
+        // Validate change
         expect(
           queryByText(cardRow, MockBetaBuildPrinting.attributes.title),
         ).toBeInTheDocument();
         expect(
           queryByText(cardRow, MockSureGamblePrinting.attributes.title),
         ).not.toBeInTheDocument();
+
+        // Validate diff
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-3${MockBetaBuildPrinting.attributes.title}+3`);
       });
 
       it("change a card's quantity", async () => {
@@ -425,12 +435,17 @@ describe("Registration", () => {
           runnerDeckTable,
           `card_${MockSureGamblePrinting.attributes.card_id}_row`,
         );
+        const runnerDiffsTable = screen.getByLabelText("runner deck changes");
 
+        // -1 quantity
         await user.click(getByRole(cardRow, "button", { name: "Remove" }));
         expect(cardRow).toHaveTextContent("2");
+        expect(runnerDiffsTable).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-1`);
 
+        // +1 quantity
         await user.click(getByRole(cardRow, "button", { name: "Add" }));
         expect(cardRow).toHaveTextContent("3");
+        expect(runnerDiffsTable).toHaveTextContent("ChangesQtyNo changes");
       });
 
       it("remove a card", async () => {
@@ -444,6 +459,7 @@ describe("Registration", () => {
 
         const runnerDeckTable = screen.getByLabelText("runner deck list");
 
+        // Remove card
         const cardRow = getByTestId(
           runnerDeckTable,
           `card_${MockSureGamblePrinting.attributes.card_id}_row`,
@@ -453,12 +469,16 @@ describe("Registration", () => {
         await user.click(removeButton);
         await user.click(removeButton);
 
+        // Validate removal
         expect(
           queryByDisplayValue(
             runnerDeckTable,
             MockSureGamblePrinting.attributes.title,
           ),
         ).not.toBeInTheDocument();
+
+        // Validate diffs
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-3`);
       });
 
       it("change an identity", async () => {
@@ -476,6 +496,7 @@ describe("Registration", () => {
 
         const cardRow = getByTestId(screen.getByLabelText("runner deck ID"), `identity_row`);
 
+        // Change identity
         await user.click(getByRole(cardRow, "button", { name: "Edit" }));
         expect(
           getByRole(cardRow, "button", { name: "Cancel" }),
@@ -487,12 +508,16 @@ describe("Registration", () => {
         await user.keyboard("{Enter}");
         await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
 
+        // Validate change
         expect(
           queryByText(cardRow, MockZahyaPrinting.attributes.title),
         ).toBeInTheDocument();
         expect(
           queryByText(cardRow, MockBazPrinting.attributes.title),
         ).not.toBeInTheDocument();
+
+        // Validate diffs
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockBazPrinting.attributes.title}-1${MockZahyaPrinting.attributes.title}+1`);
       });
     });
   });

--- a/app/frontend/tests/Registration.svelte-test.ts
+++ b/app/frontend/tests/Registration.svelte-test.ts
@@ -348,9 +348,12 @@ describe("Registration", () => {
           ),
         );
 
-        vi.mocked(transformCardLookup).mockImplementation(() =>
-          [{ label: MockBetaBuildPrinting.attributes.title, value: MockBetaBuildPrinting }]
-        );
+        vi.mocked(transformCardLookup).mockImplementation(() => [
+          {
+            label: MockBetaBuildPrinting.attributes.title,
+            value: MockBetaBuildPrinting,
+          },
+        ]);
 
         const runnerDeckTable = screen.getByLabelText("runner deck list");
 
@@ -358,21 +361,20 @@ describe("Registration", () => {
         const newCardRow = getByTestId(runnerDeckTable, "new_card_row");
         await user.type(getByRole(newCardRow, "textbox"), "beta");
         await waitFor(() => {
-          expect(getByText(newCardRow, "Build")).toBeInTheDocument()
+          expect(getByText(newCardRow, "Build")).toBeInTheDocument();
         });
         await user.keyboard("{Enter}");
 
         // Validate new card
         expect(
-          getByText(
-            runnerDeckTable,
-            MockBetaBuildPrinting.attributes.title,
-          ),
+          getByText(runnerDeckTable, MockBetaBuildPrinting.attributes.title),
         ).toBeInTheDocument();
         expect((newCardRow as HTMLInputElement).value).toBeUndefined();
 
         // Validate diff
-        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockBetaBuildPrinting.attributes.title}+1`);
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(
+          `ChangesQty${MockBetaBuildPrinting.attributes.title}+1`,
+        );
       });
 
       it("change a card", async () => {
@@ -384,9 +386,12 @@ describe("Registration", () => {
           ),
         );
 
-        vi.mocked(transformCardLookup).mockImplementation(() =>
-          [{ label: MockBetaBuildPrinting.attributes.title, value: MockBetaBuildPrinting }]
-        );
+        vi.mocked(transformCardLookup).mockImplementation(() => [
+          {
+            label: MockBetaBuildPrinting.attributes.title,
+            value: MockBetaBuildPrinting,
+          },
+        ]);
 
         let cardRow = getByTestId(
           screen.getByLabelText("runner deck list"),
@@ -407,7 +412,11 @@ describe("Registration", () => {
           screen.getByLabelText("runner deck list"),
           `card_${MockBetaBuildPrinting.attributes.card_id}_row`,
         );
-        await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
+        await waitFor(() =>
+          expect(
+            getByRole(cardRow, "button", { name: "Edit" }),
+          ).toBeInTheDocument(),
+        );
 
         // Validate change
         expect(
@@ -418,7 +427,9 @@ describe("Registration", () => {
         ).not.toBeInTheDocument();
 
         // Validate diff
-        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-3${MockBetaBuildPrinting.attributes.title}+3`);
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(
+          `ChangesQty${MockSureGamblePrinting.attributes.title}-3${MockBetaBuildPrinting.attributes.title}+3`,
+        );
       });
 
       it("change a card's quantity", async () => {
@@ -440,7 +451,9 @@ describe("Registration", () => {
         // -1 quantity
         await user.click(getByRole(cardRow, "button", { name: "Remove" }));
         expect(cardRow).toHaveTextContent("2");
-        expect(runnerDiffsTable).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-1`);
+        expect(runnerDiffsTable).toHaveTextContent(
+          `ChangesQty${MockSureGamblePrinting.attributes.title}-1`,
+        );
 
         // +1 quantity
         await user.click(getByRole(cardRow, "button", { name: "Add" }));
@@ -478,7 +491,9 @@ describe("Registration", () => {
         ).not.toBeInTheDocument();
 
         // Validate diffs
-        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockSureGamblePrinting.attributes.title}-3`);
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(
+          `ChangesQty${MockSureGamblePrinting.attributes.title}-3`,
+        );
       });
 
       it("change an identity", async () => {
@@ -490,11 +505,17 @@ describe("Registration", () => {
           ),
         );
 
-        vi.mocked(transformCardLookup).mockImplementation(() =>
-          [{ label: MockZahyaPrinting.attributes.title, value: MockZahyaPrinting }]
-        );
+        vi.mocked(transformCardLookup).mockImplementation(() => [
+          {
+            label: MockZahyaPrinting.attributes.title,
+            value: MockZahyaPrinting,
+          },
+        ]);
 
-        const cardRow = getByTestId(screen.getByLabelText("runner deck ID"), `identity_row`);
+        const cardRow = getByTestId(
+          screen.getByLabelText("runner deck ID"),
+          `identity_row`,
+        );
 
         // Change identity
         await user.click(getByRole(cardRow, "button", { name: "Edit" }));
@@ -503,10 +524,16 @@ describe("Registration", () => {
         ).toBeInTheDocument();
         await user.type(getByRole(cardRow, "textbox"), "zahya");
         await waitFor(() => {
-          expect(getByText(cardRow, "Sadeghi: Versatile Smuggler")).toBeInTheDocument()
+          expect(
+            getByText(cardRow, "Sadeghi: Versatile Smuggler"),
+          ).toBeInTheDocument();
         });
         await user.keyboard("{Enter}");
-        await waitFor(() => expect(getByRole(cardRow, "button", { name: "Edit" })).toBeInTheDocument());
+        await waitFor(() =>
+          expect(
+            getByRole(cardRow, "button", { name: "Edit" }),
+          ).toBeInTheDocument(),
+        );
 
         // Validate change
         expect(
@@ -517,7 +544,9 @@ describe("Registration", () => {
         ).not.toBeInTheDocument();
 
         // Validate diffs
-        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(`ChangesQty${MockBazPrinting.attributes.title}-1${MockZahyaPrinting.attributes.title}+1`);
+        expect(screen.getByLabelText("runner deck changes")).toHaveTextContent(
+          `ChangesQty${MockBazPrinting.attributes.title}-1${MockZahyaPrinting.attributes.title}+1`,
+        );
       });
     });
   });

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -48,6 +48,11 @@ export interface Card {
   influence_cost: number;
 }
 
+export interface CardSearchOption {
+  label: string;
+  value: Printing;
+}
+
 export class DeckDetails {
   id = 0;
   player_id: number | null = null;
@@ -233,4 +238,8 @@ export async function loadPrintings(query?: string) {
   }
 
   return null;
+}
+
+export function transformCardLookup(response: PrintingsResponse): CardSearchOption[] {
+  return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
 }

--- a/app/frontend/utils/decks.svelte.ts
+++ b/app/frontend/utils/decks.svelte.ts
@@ -240,6 +240,10 @@ export async function loadPrintings(query?: string) {
   return null;
 }
 
-export function transformCardLookup(response: PrintingsResponse): CardSearchOption[] {
-  return response.data.map((p) => { return { label: p.attributes.title, value: p }; });
+export function transformCardLookup(
+  response: PrintingsResponse,
+): CardSearchOption[] {
+  return response.data.map((p) => {
+    return { label: p.attributes.title, value: p };
+  });
 }

--- a/app/frontend/widgets/ProgressButton.svelte
+++ b/app/frontend/widgets/ProgressButton.svelte
@@ -12,6 +12,7 @@
 
   let {
     css = "btn btn-info",
+    disabled = false,
     children,
     inProgressText = "In progress",
     completeText = "Complete",
@@ -20,6 +21,7 @@
     onclick,
   }: {
     css?: string;
+    disabled?: boolean;
     children: Snippet;
     inProgressText?: string;
     completeText?: string;
@@ -48,7 +50,7 @@
   type="button"
   class={css}
   onclick={clicked}
-  disabled={state !== State.DEFAULT}
+  disabled={disabled || state !== State.DEFAULT}
 >
   {#if state === State.IN_PROGRESS}
     <span class="spinner-border spinner-border-sm m-auto"></span>


### PR DESCRIPTION
These should be the last changes needed to consider the deck registration conversion "complete", at least for the time being:
- Autocomplete is now implemented for deck editing
- Diffs are now displayed when manually adjusting decks
- The user is now redirected to the deck registration page after registering for a tournament (it works but isn't super smooth at the moment - that should be fixed when the whole things is moved to an SPA)
- Misc display and bug fixes

## Autocomplete
Previously, the entire set of printings were loaded up front and searched when card name fields were changed. This had the restriction of only succeeding for single card matches and failing if multiple matches were found. Now, no printings are loaded and the NRDB API is searched by Svelecte as the user types into a card name field. This also provides the user with a list of all possible matches for them to pick from. Most of the ugly TS diffs in `DeckDisplay` are removing all of the manual printing searching code and things are actually a bit cleaner now in the final file.

The API searching is done using the `fetch` and `fetchCallback` props of the Svelecte component. The only downside (that I've found so far) to using these is that Svelecte will automatically perform a search when the field is pre-populated, meaning that Svelecte will trigger a ton of unnecessary API calls when the user clicks the "Edit decks in place" button and all of the components are created. To get around this, I added an edit button to each card row so the Svelecte components are created one at a time (and I don't pre-populate the component here since I assume it should be clear what they are editing if they click the button). I don't think that this should be too much of a hassle for the user, but I'm open to discussion here (side note: I wonder if it's actually worth making the user click the "Edit decks in place" button in the first place or whether the page should just always be in that mode). I created the `EditableCard` component to encapsulate some of this.

Otherwise, I'm really happy with how the autocomplete is working here.

## Diffs
I moved the diffs table below the deck list instead of above it since that disrupts the page layout less and hopefully reduces scrolling back and forth, especially when adding cards. I also added a second Save button to the bottom of the page when editing decks for convenience. All of this can be moved/removed if anybody feels strongly about it.