### PR TITLE
Set up log rotation for app and db service in the deploy file.

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,9 +1,20 @@
+# Define the logging configuration once
+x-logging: &default-logging
+    logging:
+      driver: "local"
+      options:
+        max-size: "100m"
+        max-file: "7"
+        compress: "true"
+
 services:
   app:
+    logging: *default-logging
     networks:
       - backend
       - null_signal
   db:
+    logging: *default-logging
     networks:
       - backend
 


### PR DESCRIPTION
If this setup works nicely, I will deploy this to all of our docker-deployed apps.