### PR TITLE
Add explicit require for semantic_logger to fix boot dep loading error when deployed.

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'semantic_logger'
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.


### PR DESCRIPTION
Verified on the shared staging serving that this fix works.