### PR TITLE
Use a "portal" and use unique IDs to fix self-reporting on Me page.

### DIFF
--- a/app/frontend/pairings/SelfReportOptions.svelte
+++ b/app/frontend/pairings/SelfReportOptions.svelte
@@ -47,12 +47,12 @@
   type="button"
   class="btn btn-primary"
   data-toggle="modal"
-  data-target="#reportModal"
+  data-target="#reportModal-{pairing.id}"
 >
   Report Pairing
 </button>
 
-<ModalDialog id="reportModal" headerText="Report Pairing">
+<ModalDialog id="reportModal-{pairing.id}" headerText="Report Pairing">
   <p>Please click the button for the result to report this pairing:</p>
   <p>
     {left_player.name_with_pronouns} vs. {right_player.name_with_pronouns}

--- a/app/frontend/tests/MyTournamentPage.svelte-test.ts
+++ b/app/frontend/tests/MyTournamentPage.svelte-test.ts
@@ -93,7 +93,7 @@ describe("MyTournamentPage", () => {
           getByRole(currentRow, "button", { name: /report pairing/i }),
         );
 
-        const reportDialog = document.getElementById("reportModal");
+        const reportDialog = document.getElementById(`reportModal-${MockPairing1.id}`);
         expect(reportDialog).not.toBeNull();
         if (!reportDialog) {
           return;

--- a/app/frontend/tests/Rounds.svelte-test.ts
+++ b/app/frontend/tests/Rounds.svelte-test.ts
@@ -708,7 +708,7 @@ describe("Rounds", () => {
               getByRole(table1Row, "button", { name: /report pairing/i }),
             );
 
-            const reportDialog = document.getElementById("reportModal");
+            const reportDialog = document.getElementById(`reportModal-${MockPairing1.id}`);
             expect(reportDialog).not.toBeNull();
             if (!reportDialog) {
               return;

--- a/app/frontend/widgets/ModalDialog.svelte
+++ b/app/frontend/widgets/ModalDialog.svelte
@@ -10,9 +10,20 @@
   }
 
   let { id, headerText, children, footer }: Props = $props();
+
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) {
+          node.parentNode.removeChild(node);
+        }
+      }
+    };
+  }
 </script>
 
-<div {id} class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+<div {id} class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" use:portal>
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
Working screenshots:
<img width="446" height="932" alt="Screenshot 2026-07-14 at 12 22 52 AM" src="https://github.com/user-attachments/assets/5312cb7f-1c0f-411a-b140-d2054fa56b44" />
<img width="459" height="930" alt="Screenshot 2026-07-14 at 12 23 00 AM" src="https://github.com/user-attachments/assets/77dbe8a6-af30-4fb9-a5b7-e38486dfd786" />

demo of the portal thing from svelte that ended up being the solution: https://svelte.dev/playground/8364bc976f0c4ff9b83adf6e7a3c19fd?version=5.56.4