### PR TITLE
SPA - Use SvelteKit's fetch method

### DIFF
--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,13 +1,14 @@
 import { COBRA_API_SERVER } from "$app/env/public";
 import type { TournamentTypeInfo, TournamentTypesResponse } from "$lib/utils/api_types";
+import type * as Kit from "@sveltejs/kit";
 
 export interface LayoutProps {
   tournamentTypes: TournamentTypeInfo[];
 }
 
-async function loadTournamentTypes() {
+async function loadTournamentTypes(altFetch: Kit.LoadEvent["fetch"]) {
   try {
-    const response = await fetch(`${COBRA_API_SERVER}/api/v1/public/tournament_types`, {
+    const response = await altFetch(`${COBRA_API_SERVER}/api/v1/public/tournament_types`, {
       headers: {
         Accept: "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",
@@ -24,8 +25,8 @@ async function loadTournamentTypes() {
   }
 }
 
-export const load = async (): Promise<LayoutProps> => {
+export const load = async ({ fetch }) => {
 	return {
-    tournamentTypes: await loadTournamentTypes(),
+    tournamentTypes: await loadTournamentTypes(fetch as Kit.LoadEvent["fetch"]),
   };
 };

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,12 +1,11 @@
 import { COBRA_API_SERVER } from "$app/env/public";
 import type { TournamentTypeInfo, TournamentTypesResponse } from "$lib/utils/api_types";
-import type * as Kit from "@sveltejs/kit";
 
 export interface LayoutProps {
   tournamentTypes: TournamentTypeInfo[];
 }
 
-async function loadTournamentTypes(altFetch: Kit.LoadEvent["fetch"]) {
+async function loadTournamentTypes(altFetch: typeof globalThis.fetch) {
   try {
     const response = await altFetch(`${COBRA_API_SERVER}/api/v1/public/tournament_types`, {
       headers: {
@@ -27,6 +26,6 @@ async function loadTournamentTypes(altFetch: Kit.LoadEvent["fetch"]) {
 
 export const load = async ({ fetch }) => {
 	return {
-    tournamentTypes: await loadTournamentTypes(fetch as Kit.LoadEvent["fetch"]),
+    tournamentTypes: await loadTournamentTypes(fetch as typeof globalThis.fetch),
   };
 };

--- a/frontend/src/routes/tournaments/+page.ts
+++ b/frontend/src/routes/tournaments/+page.ts
@@ -1,7 +1,6 @@
 import type { PageLoad } from "./$types";
 import { loadTournaments, tournamentsApiUrl } from "./api_helper";
 
-// TODO: Use fetch parameter
 export const load: PageLoad = async ({ fetch }) => {
   return {
     tournamentsResponse: await loadTournaments(tournamentsApiUrl(), fetch),

--- a/frontend/src/routes/tournaments/+page.ts
+++ b/frontend/src/routes/tournaments/+page.ts
@@ -2,8 +2,8 @@ import type { PageLoad } from "./$types";
 import { loadTournaments, tournamentsApiUrl } from "./api_helper";
 
 // TODO: Use fetch parameter
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ fetch }) => {
   return {
-    tournamentsResponse: await loadTournaments(tournamentsApiUrl()),
+    tournamentsResponse: await loadTournaments(tournamentsApiUrl(), fetch),
   };
 }

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -1,9 +1,8 @@
 import { COBRA_API_SERVER } from "$app/env/public";
 import type { TournamentsResponse } from "$lib/utils/api_types";
 import { globalMessages } from "$lib/utils/GlobalMessageState.svelte";
-import type * as Kit from "@sveltejs/kit";
 
-export async function loadTournaments(url: string, altFetch: Kit.LoadEvent["fetch"] = fetch): Promise<TournamentsResponse> {
+export async function loadTournaments(url: string, altFetch = fetch): Promise<TournamentsResponse> {
   try {
     const response = await altFetch(url, {
       headers: {

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -1,10 +1,11 @@
 import { COBRA_API_SERVER } from "$app/env/public";
 import type { TournamentsResponse } from "$lib/utils/api_types";
 import { globalMessages } from "$lib/utils/GlobalMessageState.svelte";
+import type * as Kit from "@sveltejs/kit";
 
-export async function loadTournaments(url: string): Promise<TournamentsResponse> {
+export async function loadTournaments(url: string, altFetch: Kit.LoadEvent["fetch"] = fetch): Promise<TournamentsResponse> {
   try {
-    const response = await fetch(url, {
+    const response = await altFetch(url, {
       headers: {
         Accept: "application/vnd.api+json",
         "Content-Type": "application/vnd.api+json",

--- a/frontend/src/routes/tournaments/type/[typeId]/+page.ts
+++ b/frontend/src/routes/tournaments/type/[typeId]/+page.ts
@@ -1,7 +1,6 @@
 import type { PageLoad } from "./$types";
 import { loadTournaments, tournamentsApiUrl } from "../../api_helper";
 
-// TODO: Use fetch parameter
 export const load: PageLoad = async ({ params, fetch }) => {
   return {
     tournamentsResponse: await loadTournaments(tournamentsApiUrl(params.typeId), fetch),

--- a/frontend/src/routes/tournaments/type/[typeId]/+page.ts
+++ b/frontend/src/routes/tournaments/type/[typeId]/+page.ts
@@ -2,8 +2,8 @@ import type { PageLoad } from "./$types";
 import { loadTournaments, tournamentsApiUrl } from "../../api_helper";
 
 // TODO: Use fetch parameter
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, fetch }) => {
   return {
-    tournamentsResponse: await loadTournaments(tournamentsApiUrl(params.typeId)),
+    tournamentsResponse: await loadTournaments(tournamentsApiUrl(params.typeId), fetch),
   };
 }


### PR DESCRIPTION
There are big warnings in the browser console currently because [SvelteKit provides its own `fetch()`](https://svelte.dev/docs/kit/load#Making-fetch-requests) method that it wants you to use in `load()`. These changes make use of that.

This is the best I've been able to do so far to resolve the typing errors that arise when trying to use this, especially when trying to pass the `fetch()` method to any sort of helper function. It's a little clunky, but it's not the worst.