### PR TITLE
Update a couple of spots that were missed for dark mode changes.

### DIFF
--- a/app/frontend/pairings/PlayerDisplay.svelte
+++ b/app/frontend/pairings/PlayerDisplay.svelte
@@ -29,8 +29,8 @@
 {#snippet setSideButton(player: Player, side: string)}
   <button
     class="btn btn-sm mr-1 {player.side === side
-      ? 'btn-dark'
-      : 'btn-outline-dark'}"
+      ? 'btn-secondary'
+      : 'btn-outline-secondary'}"
     onclick={() => {
       changePlayerSide?.(player, side);
     }}

--- a/app/frontend/tournaments/MyTournamentPage.svelte
+++ b/app/frontend/tournaments/MyTournamentPage.svelte
@@ -171,7 +171,7 @@
                   </td>
                   <td>{isBye(myPairing) ? "" : myPairing.table_number}</td>
                   {#if myPairing.stage.is_single_sided}
-                    <td style="background-color: #eeeeee" class={iWon(myPairing) ? "font-weight-bold" : ""}>
+                    <td class={iWon(myPairing) ? "font-weight-bold" : ""}>
                       {#if !isBye(myPairing)}
                         <PlayerDisplay
                           player={myPairing.player1.user_id === userId

--- a/app/helpers/pairings_helper.rb
+++ b/app/helpers/pairings_helper.rb
@@ -54,7 +54,7 @@ module PairingsHelper # rubocop:disable Metrics/ModuleLength,Style/Documentation
             ),
             method: :post,
             data: { confirm: "Are you sure you want to switch #{player.name} to #{side}?" },
-            class: "btn btn-sm mr-1 #{active ? 'btn-dark' : 'btn-outline-dark'}"
+            class: "btn btn-sm mr-1 #{active ? 'btn-secondary' : 'btn-outline-secondary'}"
   end
 
   def presets(pairing)


### PR DESCRIPTION
@migueldlr reported the "Me" page issue and there were a couple more instances of that same problem.

New Me:
<img width="1133" height="639" alt="Screenshot 2026-08-10 at 8 54 24 AM" src="https://github.com/user-attachments/assets/98ad40ad-2f3d-4547-8c49-500337353547" />

Side selection on pairings:

Classic (before & after)
<img width="1155" height="657" alt="classic-side-selection-before" src="https://github.com/user-attachments/assets/7c6ce7d4-9567-4d12-9f0e-ab2fb9a8f051" />
<img width="1149" height="649" alt="classic-side-selection-after" src="https://github.com/user-attachments/assets/192b6665-2352-461a-9f3f-d9099e9be77b" />


Beta (before & after)

<img width="1135" height="752" alt="beta-side-selection-before" src="https://github.com/user-attachments/assets/1ee0c3ab-cd8b-4104-80e4-c252f9d9e3eb" />
<img width="1137" height="741" alt="beta-side-selection-after" src="https://github.com/user-attachments/assets/b2be5a44-2c4b-4c0a-a52a-00371c727c30" />
