### PR TITLE
Add demo tournament to frontend

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,6 +86,9 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  # Disable to allow full Svelte app access to the backend for dev.
+  config.action_controller.forgery_protection_origin_check = false
+
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -96,6 +96,10 @@
               <FontAwesomeIcon icon="trophy" />
               My tournaments
             </a>
+            <a href={resolve("/tournaments/demo")} class="dropdown-item">
+              <FontAwesomeIcon icon="plus" />
+              Create demo tournament
+            </a>
             <div class="dropdown-divider"></div>
             <a href={getLogoutUrl()} rel="external" class="dropdown-item">
               <FontAwesomeIcon icon="sign-out" />

--- a/frontend/src/routes/tournaments/demo/+page.svelte
+++ b/frontend/src/routes/tournaments/demo/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import {
+    createDemoTournament,
+    type Errors,
+    loadNewDemoTournament,
+    type DemoTournamentSettings,
+    ValidationError,
+    navigateTo,
+  } from "./DemoTournamentSettings";
+  import DemoTournamentSettingsForm from "./DemoTournamentSettingsForm.svelte";
+
+  let tournament = $state<DemoTournamentSettings | undefined>(undefined);
+  let csrfToken = "";
+  let errors = $state<Errors>({});
+
+  onMount(async () => {
+    const data = await loadNewDemoTournament();
+    tournament = data.tournament;
+    csrfToken = data.csrf_token;
+  });
+
+  async function submitNewTournament(tournament: DemoTournamentSettings) {
+    errors = {};
+
+    try {
+      const response = await createDemoTournament(csrfToken, tournament);
+      navigateTo(response.url);
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        errors = error.errors;
+      } else {
+        errors = { base: ["An unexpected error occurred. Please try again."] };
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+</script>
+
+<div class="row">
+  <div class="col-12">
+    <h1>Create a demo tournament</h1>
+    <p>
+      This allows you to create a private tournament with certain parameters,
+      demo players with fake names, and specific rounds.
+    </p>
+
+    {#if errors.base}
+      <div class="alert alert-danger">{errors.base}</div>
+    {:else if tournament}
+      <DemoTournamentSettingsForm
+        {tournament}
+        onSubmitCallback={submitNewTournament}
+        submitLabel="Create"
+        submitIcon="plus"
+        {errors}
+      />
+    {:else}
+      <div class="d-flex align-items-center m-2" data-testid="loading-spinner">
+        <div class="spinner-border m-auto"></div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/routes/tournaments/demo/DemoTournamentCreation.svelte.test.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentCreation.svelte.test.ts
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import DemoTournamentCreation from "./+page.svelte";
+import {
+  ValidationError,
+  loadNewDemoTournament,
+  createDemoTournament,
+  navigateTo,
+} from "./DemoTournamentSettings";
+
+// Mock the DemoTournamentSettings module
+vi.mock("./DemoTournamentSettings", () => {
+  return {
+    loadNewDemoTournament: vi.fn(),
+    createDemoTournament: vi.fn(),
+    navigateTo: vi.fn(),
+    ValidationError: class ValidationError extends Error {
+      constructor(public errors: Record<string, string[]>) {
+        super("Validation failed");
+        this.name = "ValidationError";
+      }
+    },
+  };
+});
+
+describe("DemoTournamentCreation", () => {
+  const mockTournamentData = {
+    tournament: {
+      name: "Test Demo Tournament",
+      swiss_format: "single_sided",
+      num_players: 16,
+      num_first_round_byes: 1,
+      assign_ids: true,
+    },
+    csrf_token: "fake-csrf-token",
+  };
+
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.mocked(loadNewDemoTournament).mockResolvedValue(mockTournamentData);
+  });
+
+  it("renders the demo tournament creation form", async () => {
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Create a demo tournament")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Number of Players/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/swiss format/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/number of first round byes/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/assign random ids for players\?/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+
+  it("loads initial tournament data on mount", async () => {
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(loadNewDemoTournament).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows a loading spinner", async () => {
+    vi.mocked(loadNewDemoTournament).mockImplementation(
+      () =>
+        new Promise(() => {
+          // This promise intentionally never resolves to test loading state
+        }),
+    );
+
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/tournament name/i)).not.toBeInTheDocument();
+  });
+
+  it("successfully creates a tournament", async () => {
+    const mockResponse = {
+      id: 123,
+      name: "Test Demo Tournament",
+      url: "/tournaments/123/rounds",
+    };
+
+    vi.mocked(createDemoTournament).mockResolvedValue(mockResponse);
+
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    // Fill in the form
+    const nameInput = screen.getByLabelText(/tournament name/i);
+    await fireEvent.input(nameInput, {
+      target: { value: "Test Demo Tournament" },
+    });
+    const formatInput = screen.getByLabelText(/swiss format/i);
+    await fireEvent.change(formatInput, { target: { value: "Single-sided" } });
+    const numPlayersInput = screen.getByLabelText(/number of players/i);
+    await fireEvent.input(numPlayersInput, { target: { value: "16" } });
+    const numByesInput = screen.getByLabelText(/number of first round byes/i);
+    await fireEvent.input(numByesInput, { target: { value: "1" } });
+    const assignIdsCheckbox = screen.getByLabelText(
+      /assign random ids for players\?/i,
+    );
+    await fireEvent.click(assignIdsCheckbox);
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(createDemoTournament).toHaveBeenCalledWith(
+        "fake-csrf-token",
+        expect.objectContaining({
+          name: "Test Demo Tournament",
+        }),
+      );
+    });
+
+    // Check that redirect happens
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith("/tournaments/123/rounds");
+    });
+  });
+
+  it("handles validation errors", async () => {
+    const validationError = new ValidationError({
+      name: ["You must provide a name for the tournament"],
+      num_players: ["Number of players is required"],
+      num_first_round_byes: ["Number of byes must be a number"],
+    });
+    vi.mocked(createDemoTournament).mockRejectedValue(validationError);
+
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    const numByesInput = screen.getByLabelText(/number of first round byes/i);
+    await fireEvent.input(numByesInput, {
+      target: { value: "plural is not a number" },
+    });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You must provide a name for the tournament"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Number of players is required"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Number of byes must be a number"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("handles unexpected errors", async () => {
+    vi.mocked(createDemoTournament).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    render(DemoTournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/an unexpected error occurred/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  loadNewDemoTournament,
+  createDemoTournament,
+  ValidationError,
+} from "./DemoTournamentSettings";
+
+describe("DemoTournamentSettings", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("loadNewDemoTournament", () => {
+    it("fetches new tournament form data", async () => {
+      const mockData = {
+        tournament: {
+          name: undefined,
+          swiss_format: "single_sided",
+          num_players: undefined,
+          num_first_round_byes: undefined,
+          assign_ids: false,
+        },
+        csrf_token: "mock-csrf-token",
+      };
+
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      const result = await loadNewDemoTournament();
+      expect(result).toEqual(mockData);
+    });
+
+    it("handles network errors", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+
+      await expect(loadNewDemoTournament()).rejects.toThrow();
+    });
+  });
+
+  describe("createDemoTournament", () => {
+    it("creates a demo tournament", async () => {
+      const mockResponse = {
+        id: 123,
+        name: "Test Demo Tournament",
+        url: "/tournaments/123/rounds",
+      };
+
+      const tournament = {
+        name: "Test Tournament",
+        swiss_format: "single_sided",
+        num_players: 8,
+        num_first_round_byes: 0,
+        assign_ids: false,
+      };
+
+      vi.spyOn(global, "fetch").mockImplementation(async (_url, init) => {
+        const headers = (init?.headers || {}) as Record<string, string>;
+        expect(headers["Content-Type"]).toBe("application/json");
+        expect(headers["Accept"]).toBe("application/json");
+        expect(headers["X-CSRF-Token"]).toBe("mock-csrf-token");
+        expect(init?.body).toBe(JSON.stringify({ tournament }));
+
+        return {
+          ok: true,
+          json: async () => mockResponse,
+        } as Response;
+      });
+
+      const result = await createDemoTournament("mock-csrf-token", tournament);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("handles validation errors", async () => {
+      const mockErrors = {
+        errors: {
+          name: ["Name is required"],
+          first_round_byes: ["Number of byes must be a number"],
+        },
+      };
+
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => mockErrors,
+      } as Response);
+
+      const tournament = { name: "" };
+
+      await expect(
+        createDemoTournament("mock-csrf-token", tournament),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("handles server errors", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+
+      const tournament = { name: "Test" };
+
+      await expect(
+        createDemoTournament("mock-csrf-token", tournament),
+      ).rejects.toThrow("HTTP 500: Internal Server Error");
+    });
+  });
+});

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
@@ -25,8 +25,8 @@ describe("DemoTournamentSettings", () => {
 
       vi.spyOn(global, "fetch").mockResolvedValue({
         ok: true,
-        json: async () => mockData,
-      } as Response);
+        json: () => mockData,
+      } as unknown as Response);
 
       const result = await loadNewDemoTournament();
       expect(result).toEqual(mockData);
@@ -59,17 +59,17 @@ describe("DemoTournamentSettings", () => {
         assign_ids: false,
       };
 
-      vi.spyOn(global, "fetch").mockImplementation(async (_url, init) => {
-        const headers = (init?.headers || {}) as Record<string, string>;
+      vi.spyOn(global, "fetch").mockImplementation((_url, init) => {
+        const headers = (init?.headers ?? {}) as Record<string, string>;
         expect(headers["Content-Type"]).toBe("application/json");
-        expect(headers["Accept"]).toBe("application/json");
+        expect(headers.Accept).toBe("application/json");
         expect(headers["X-CSRF-Token"]).toBe("mock-csrf-token");
         expect(init?.body).toBe(JSON.stringify({ tournament }));
 
-        return {
+        return Promise.resolve({
           ok: true,
-          json: async () => mockResponse,
-        } as Response;
+          json: () => mockResponse,
+        } as unknown as Response);
       });
 
       const result = await createDemoTournament("mock-csrf-token", tournament);
@@ -87,8 +87,8 @@ describe("DemoTournamentSettings", () => {
       vi.spyOn(global, "fetch").mockResolvedValue({
         ok: false,
         status: 422,
-        json: async () => mockErrors,
-      } as Response);
+        json: () => mockErrors,
+      } as unknown as Response);
 
       const tournament = { name: "" };
 

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
@@ -1,0 +1,102 @@
+import { COBRA_API_SERVER } from "$app/env/public";
+
+export type Errors = Record<string, string[]>;
+
+declare const Routes: {
+  new_demo_form_tournaments_path: () => string;
+  create_demo_tournaments_path: () => string;
+};
+
+export interface DemoTournamentSettings {
+  id?: number;
+  name?: string;
+  swiss_format?: string;
+  num_players?: number;
+  num_first_round_byes?: number;
+  assign_ids?: boolean;
+}
+
+export interface DemoTournamentSettingsData {
+  tournament: DemoTournamentSettings;
+  csrf_token: string;
+}
+
+function getNewDemoFormUrl(): string {
+  if (typeof Routes !== "undefined" && Routes.new_demo_form_tournaments_path) {
+    return Routes.new_demo_form_tournaments_path();
+  }
+  const serverOrigin = (COBRA_API_SERVER || "").replace(/\/$/, "");
+  return `${serverOrigin}/tournaments/new_demo_form`;
+}
+
+function getCreateDemoUrl(): string {
+  if (typeof Routes !== "undefined" && Routes.create_demo_tournaments_path) {
+    return Routes.create_demo_tournaments_path();
+  }
+  const serverOrigin = (COBRA_API_SERVER || "").replace(/\/$/, "");
+  return `${serverOrigin}/tournaments/create_demo`;
+}
+
+export async function loadNewDemoTournament(): Promise<DemoTournamentSettingsData> {
+  const response = await fetch(getNewDemoFormUrl(), {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+    method: "GET",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status.toString()}: ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as DemoTournamentSettingsData;
+}
+
+export interface TournamentDemoCreateResponse {
+  id: number;
+  name: string;
+  url: string;
+}
+
+export interface TournamentDemoCreateErrorResponse {
+  errors: Errors;
+}
+
+export async function createDemoTournament(
+  csrfToken: string,
+  tournament: DemoTournamentSettings,
+): Promise<TournamentDemoCreateResponse> {
+  const response = await fetch(getCreateDemoUrl(), {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-CSRF-Token": csrfToken,
+    },
+    body: JSON.stringify({ tournament }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 422) {
+      const errorData =
+        (await response.json()) as TournamentDemoCreateErrorResponse;
+      throw new ValidationError(errorData.errors);
+    }
+    throw new Error(
+      `HTTP ${response.status.toString()}: ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as TournamentDemoCreateResponse;
+}
+
+export class ValidationError extends Error {
+  constructor(public errors: Errors) {
+    super("Validation failed");
+    this.name = "ValidationError";
+  }
+}
+
+export function navigateTo(url: string) {
+  window.location.href = url;
+}

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
@@ -2,11 +2,6 @@ import { COBRA_API_SERVER } from "$app/env/public";
 
 export type Errors = Record<string, string[]>;
 
-declare const Routes: {
-  new_demo_form_tournaments_path: () => string;
-  create_demo_tournaments_path: () => string;
-};
-
 export interface DemoTournamentSettings {
   id?: number;
   name?: string;
@@ -22,17 +17,11 @@ export interface DemoTournamentSettingsData {
 }
 
 function getNewDemoFormUrl(): string {
-  if (typeof Routes !== "undefined" && Routes.new_demo_form_tournaments_path) {
-    return Routes.new_demo_form_tournaments_path();
-  }
   const serverOrigin = (COBRA_API_SERVER || "").replace(/\/$/, "");
   return `${serverOrigin}/tournaments/new_demo_form`;
 }
 
 function getCreateDemoUrl(): string {
-  if (typeof Routes !== "undefined" && Routes.create_demo_tournaments_path) {
-    return Routes.create_demo_tournaments_path();
-  }
   const serverOrigin = (COBRA_API_SERVER || "").replace(/\/$/, "");
   return `${serverOrigin}/tournaments/create_demo`;
 }

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettingsForm.svelte
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettingsForm.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import {
+    type DemoTournamentSettings,
+    type Errors,
+  } from "./DemoTournamentSettings";
+  import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import ProgressButton from "$lib/components/ProgressButton.svelte";
+
+  // TODO(plural): Replace with appropriate library.
+  function swissFormatDisplayString(format: string) {
+    if (format === "single_sided") {
+      return "Single-sided";
+    } else if (format === "double_sided") {
+      return "Double-sided";
+    }
+    return "Unknown";
+  }
+
+  let {
+    tournament,
+    submitLabel = "Save",
+    submitIcon = "floppy-o",
+    errors = {},
+    onSubmitCallback,
+  }: {
+    tournament: DemoTournamentSettings;
+    submitLabel?: string;
+    submitIcon?: string;
+    errors?: Errors;
+    onSubmitCallback?: (tournament: DemoTournamentSettings) => Promise<boolean>;
+  } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let tournamentEdit = $state($state.snapshot(tournament));
+</script>
+
+<div class="form-group">
+  <label for="name"><abbr title="required">*</abbr> Tournament name</label>
+  <input
+    type="text"
+    id="name"
+    class="form-control"
+    bind:value={tournamentEdit.name}
+  />
+  {#if errors.name}
+    <div class="invalid-feedback d-block">{errors.name}</div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="swiss_format">Swiss format</label>
+  <select
+    id="swiss_format"
+    class="form-control"
+    bind:value={tournamentEdit.swiss_format}
+  >
+    <option value="double_sided">{swissFormatDisplayString("double_sided")}</option>
+    <option value="single_sided">{swissFormatDisplayString("single_sided")}</option>
+  </select>
+  {#if errors.swiss_format}
+    <div class="invalid-feedback d-block">{errors.swiss_format}</div>
+  {/if}
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="num_players">Number of Players</label>
+      <input
+        type="text"
+        id="num_players"
+        class="form-control"
+        bind:value={tournamentEdit.num_players}
+      />
+      {#if errors.num_players}
+        <div class="invalid-feedback d-block">{errors.num_players}</div>
+      {/if}
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="num_first_round_byes">Number of First Round Byes</label>
+      <input
+        type="text"
+        id="num_first_round_byes"
+        class="form-control"
+        bind:value={tournamentEdit.num_first_round_byes}
+      />
+      {#if errors.num_first_round_byes}
+        <div class="invalid-feedback d-block">
+          {errors.num_first_round_byes}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="assign_ids"
+    class="form-check-input"
+    bind:checked={tournamentEdit.assign_ids}
+  />
+  <label for="assign_ids" class="form-check-label">
+    Assign random IDs for players?
+  </label>
+</div>
+
+<ProgressButton
+  css="btn btn-primary"
+  inProgressText="Saving"
+  completeText="Saved"
+  onclick={() => {
+    return onSubmitCallback ? onSubmitCallback(tournamentEdit) : false;
+  }}
+>
+  <FontAwesomeIcon icon={submitIcon} />
+  {submitLabel}
+</ProgressButton>


### PR DESCRIPTION
This works, but will 404 after create because the tournament pages aren't in place on the Svelte app yet.

A couple of these files are identical, others have minimal changes.

The CRSF thing on the rails side was needed since these are serving on different ports right now.  Adding that to the list of deployment issues to sort.