### PR TITLE
SPA - Create Tournament page

### DIFF
--- a/frontend/src/lib/model/Tournament.ts
+++ b/frontend/src/lib/model/Tournament.ts
@@ -1,0 +1,92 @@
+export class Tournament {
+  id = 0;
+  name = "";
+  slug: string | null = null;
+  abr_code: string | null = null;
+  private = false;
+  user_id = 0;
+  tournament_organizer = "";
+  date = "";
+  time_zone: string | null = null;
+  registration_starts: string | null = null;
+  tournament_starts: string | null = null;
+  organizer_contact: string | null = null;
+  event_link: string | null = null;
+  stream_url = "";
+  description: string | null = null;
+  additional_prizes_description: string | null = null;
+  official_prize_kit_id: number | null = null;
+  official_prize_kit_name: string | null = null;
+  stage = "";
+  manual_seed = false;
+  self_registration = false;
+  nrdb_deck_registration = false;
+  decklist_required = false;
+  allow_self_reporting = false;
+  allow_streaming_opt_out = false;
+  all_players_unlocked = false;
+  any_player_unlocked = false;
+  registration_closed: boolean | null = null;
+  swiss_deck_visibility = SwissDeckVisibility.Private;
+  cut_deck_visibility = CutDeckVisibility.Private;
+  swiss_format = "";
+  tournament_type_id: number | null = null;
+  format_id: number | null = null;
+  format_name: string | null = null;
+  deckbuilding_restriction_id: number | null = null;
+  deckbuilding_restriction_name: string | null = null;
+  card_set_id: number | null = null;
+  active_player_count = 0;
+  dropped_player_count = 0;
+  created_at = "";
+  updated_at = "";
+
+  constructor(init?: Partial<Tournament>) {
+    Object.assign(this, init);
+  }
+}
+
+export interface TournamentOptions {
+  tournament_types: { id: number; name: string }[];
+  formats: { id: number; name: string }[];
+  card_sets: { id: number; name: string }[];
+  deckbuilding_restrictions: { id: number; name: string }[];
+  time_zones: { id: string; name: string }[];
+  official_prize_kits: { id: number; name: string }[];
+}
+
+export interface FeatureFlags {
+  allow_self_reporting?: boolean;
+}
+
+export enum SwissDeckVisibility {
+  Private = "swiss_decks_private",
+  Open = "swiss_decks_open",
+  Public = "swiss_decks_public",
+}
+
+export enum CutDeckVisibility {
+  Private = "cut_decks_private",
+  Open = "cut_decks_open",
+  Public = "cut_decks_public",
+}
+
+export function swissFormatDisplayString(format: string) {
+  if (format === "single_sided") {
+    return "Single-sided";
+  } else if (format === "double_sided") {
+    return "Double-sided";
+  }
+  return "Unknown";
+}
+
+export function emptyTournamentOptions(): TournamentOptions {
+  return {
+    tournament_types: [],
+    formats: [],
+    card_sets: [],
+    deckbuilding_restrictions: [],
+    time_zones: [],
+    official_prize_kits: [],
+  };
+}

--- a/frontend/src/lib/utils/errors.ts
+++ b/frontend/src/lib/utils/errors.ts
@@ -1,0 +1,8 @@
+export type Errors = Record<string, string[]>;
+
+export class ValidationError extends Error {
+  constructor(public errors: Errors) {
+    super("Validation failed");
+    this.name = "ValidationError";
+  }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -125,7 +125,7 @@
   </div>
 </nav>
 
-<div class="container">
+<div class="container py-3">
   {@render children()}
 </div>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -92,13 +92,17 @@
             {/if}
           </button>
           <div class="dropdown-menu dropdown-menu-right">
-            <a href={resolve("/tournaments/my")} class="dropdown-item">
-              <FontAwesomeIcon icon="trophy" />
-              My tournaments
+            <a href={resolve("/tournaments/new")} class="dropdown-item">
+              <FontAwesomeIcon icon="plus" />
+              Create tournament
             </a>
             <a href={resolve("/tournaments/demo")} class="dropdown-item">
               <FontAwesomeIcon icon="plus" />
               Create demo tournament
+            </a>
+            <a href={resolve("/tournaments/my")} class="dropdown-item">
+              <FontAwesomeIcon icon="trophy" />
+              My tournaments
             </a>
             <div class="dropdown-divider"></div>
             <a href={getLogoutUrl()} rel="external" class="dropdown-item">

--- a/frontend/src/routes/tournaments/TournamentSettingsForm.svelte
+++ b/frontend/src/routes/tournaments/TournamentSettingsForm.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import ProgressButton from "$lib/components/ProgressButton.svelte";
+  import { emptyTournamentOptions, swissFormatDisplayString, type FeatureFlags, type Tournament, type TournamentOptions } from "$lib/model/Tournament";
+  import { type Errors } from "$lib/utils/errors";
+
+  let {
+    tournament,
+    options = emptyTournamentOptions(),
+    featureFlags = {},
+    submitLabel = "Save",
+    submitIcon = "floppy-o",
+    errors = {},
+    onSubmitCallback,
+  }: {
+    tournament: Tournament;
+    options?: TournamentOptions;
+    featureFlags?: FeatureFlags;
+    submitLabel?: string;
+    submitIcon?: string;
+    errors?: Errors;
+    onSubmitCallback?: (tournament: Tournament) => Promise<boolean>;
+  } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let tournamentEdit = $state($state.snapshot(tournament));
+</script>
+
+<div class="form-group">
+  <label for="name"><abbr title="required">*</abbr> Tournament name</label>
+  <input
+    type="text"
+    id="name"
+    class="form-control"
+    bind:value={tournamentEdit.name}
+  />
+  {#if errors.name}
+    <div class="invalid-feedback d-block">{errors.name}</div>
+  {/if}
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="date">Date</label>
+      <input
+        type="date"
+        id="date"
+        class="form-control"
+        bind:value={tournamentEdit.date}
+      />
+      {#if errors.date}
+        <div class="invalid-feedback d-block">{errors.date}</div>
+      {/if}
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="time_zone">Time zone</label>
+      <select
+        id="time_zone"
+        class="form-control"
+        bind:value={tournamentEdit.time_zone}
+      >
+        {#each options.time_zones as time_zone (time_zone.id)}
+          <option value={time_zone.id}>{time_zone.name}</option>
+        {/each}
+      </select>
+      {#if errors.time_zone}
+        <div class="invalid-feedback d-block">{errors.time_zone}</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="registration_starts">Registration starts</label>
+      <input
+        type="time"
+        id="registration_starts"
+        class="form-control"
+        bind:value={tournamentEdit.registration_starts}
+      />
+      {#if errors.registration_starts}
+        <div class="invalid-feedback d-block">{errors.registration_starts}</div>
+      {/if}
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="tournament_starts">Tournament starts</label>
+      <input
+        type="time"
+        id="tournament_starts"
+        class="form-control"
+        bind:value={tournamentEdit.tournament_starts}
+      />
+      {#if errors.tournament_starts}
+        <div class="invalid-feedback d-block">{errors.tournament_starts}</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<div class="form-group">
+  <label for="swiss_format">Swiss format</label>
+  <select
+    id="swiss_format"
+    class="form-control"
+    bind:value={tournamentEdit.swiss_format}
+  >
+    <option value="double_sided">{swissFormatDisplayString("double_sided")}</option>
+    <option value="single_sided">{swissFormatDisplayString("single_sided")}</option>
+  </select>
+  {#if errors.swiss_format}
+    <div class="invalid-feedback d-block">{errors.swiss_format}</div>
+  {/if}
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="tournament_type_id">Tournament Type</label>
+      <select
+        id="tournament_type_id"
+        class="form-control"
+        bind:value={tournamentEdit.tournament_type_id}
+      >
+        <option value=""></option>
+        {#each options.tournament_types as tournament_type (tournament_type.id)}
+          <option value={tournament_type.id}>{tournament_type.name}</option>
+        {/each}
+      </select>
+      {#if errors.tournament_type_id}
+        <div class="invalid-feedback d-block">{errors.tournament_type_id}</div>
+      {/if}
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="card_set_id">Legal Cardpool Up To</label>
+      <select
+        id="card_set_id"
+        class="form-control"
+        bind:value={tournamentEdit.card_set_id}
+      >
+        <option value=""></option>
+        {#each options.card_sets as card_set (card_set.id)}
+          <option value={card_set.id}>{card_set.name}</option>
+        {/each}
+      </select>
+      {#if errors.card_set_id}
+        <div class="invalid-feedback d-block">{errors.card_set_id}</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="format_id">Play Format</label>
+      <select
+        id="format_id"
+        class="form-control"
+        bind:value={tournamentEdit.format_id}
+      >
+        <option value=""></option>
+        {#each options.formats as format (format.id)}
+          <option value={format.id}>{format.name}</option>
+        {/each}
+      </select>
+      {#if errors.format_id}
+        <div class="invalid-feedback d-block">{errors.format_id}</div>
+      {/if}
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-group">
+      <label for="deckbuilding_restriction_id">Deckbuilding Restriction</label>
+      <select
+        id="deckbuilding_restriction_id"
+        class="form-control"
+        bind:value={tournamentEdit.deckbuilding_restriction_id}
+      >
+        <option value=""></option>
+        {#each options.deckbuilding_restrictions as restriction (restriction.id)}
+          <option value={restriction.id}>{restriction.name}</option>
+        {/each}
+      </select>
+      {#if errors.deckbuilding_restriction_id}
+        <div class="invalid-feedback d-block">
+          {errors.deckbuilding_restriction_id}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="decklist_required"
+    class="form-check-input"
+    bind:checked={tournamentEdit.decklist_required}
+  />
+  <label for="decklist_required" class="form-check-label">
+    Decklist required for event
+  </label>
+</div>
+
+<div class="form-group">
+  <label for="organizer_contact">Organizer Contact Information</label>
+  <input
+    type="text"
+    id="organizer_contact"
+    class="form-control"
+    bind:value={tournamentEdit.organizer_contact}
+  />
+  {#if errors.organizer_contact}
+    <div class="invalid-feedback d-block">{errors.organizer_contact}</div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="event_link">External Event Link</label>
+  <input
+    type="url"
+    id="event_link"
+    class="form-control"
+    bind:value={tournamentEdit.event_link}
+  />
+  {#if errors.event_link}
+    <div class="invalid-feedback d-block">{errors.event_link}</div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="description">Event Description (Markdown format supported)</label>
+  <textarea
+    id="description"
+    class="form-control"
+    bind:value={tournamentEdit.description}
+  ></textarea>
+  {#if errors.description}
+    <div class="invalid-feedback d-block">{errors.description}</div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="official_prize_kit_id">Official Prize Kit</label>
+  <select
+    id="official_prize_kit_id"
+    class="form-control"
+    bind:value={tournamentEdit.official_prize_kit_id}
+  >
+    <option value=""></option>
+    {#each options.official_prize_kits as prize_kit (prize_kit.id)}
+      <option value={prize_kit.id}>{prize_kit.name}</option>
+    {/each}
+  </select>
+  {#if errors.official_prize_kit_id}
+    <div class="invalid-feedback d-block">{errors.official_prize_kit_id}</div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="additional_prizes_description"
+    >Additional Prize Information (Markdown format supported)</label
+  >
+  <textarea
+    id="additional_prizes_description"
+    class="form-control"
+    bind:value={tournamentEdit.additional_prizes_description}
+  ></textarea>
+  {#if errors.additional_prizes_description}
+    <div class="invalid-feedback d-block">
+      {errors.additional_prizes_description}
+    </div>
+  {/if}
+</div>
+
+<div class="form-group">
+  <label for="stream_url">Stream URL</label>
+  <input
+    type="url"
+    id="stream_url"
+    class="form-control"
+    bind:value={tournamentEdit.stream_url}
+  />
+  {#if errors.stream_url}
+    <div class="invalid-feedback d-block">{errors.stream_url}</div>
+  {/if}
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="self_registration"
+    class="form-check-input"
+    bind:checked={tournamentEdit.self_registration}
+  />
+  <label for="self_registration" class="form-check-label">
+    Self-Registration: Allow players to use a link to register themselves
+  </label>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="nrdb_deck_registration"
+    class="form-check-input"
+    bind:checked={tournamentEdit.nrdb_deck_registration}
+  />
+  <label for="nrdb_deck_registration" class="form-check-label">
+    Deck registration: Upload decks from NetrunnerDB
+  </label>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="private"
+    class="form-check-input"
+    bind:checked={tournamentEdit.private}
+  />
+  <label for="private" class="form-check-label">
+    Private: Only I will be able to view this tournament
+  </label>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="manual_seed"
+    class="form-check-input"
+    bind:checked={tournamentEdit.manual_seed}
+  />
+  <label for="manual_seed" class="form-check-label">
+    Use manual seeding for tiebreakers: Players can be assigned a "seed" value
+    that will be used before all other tiebreakers (in ascending order; i.e.
+    Seed 1 wins all ties)
+  </label>
+</div>
+
+<div class="form-check mb-3">
+  <input
+    type="checkbox"
+    id="allow_streaming_opt_out"
+    class="form-check-input"
+    bind:checked={tournamentEdit.allow_streaming_opt_out}
+  />
+  <label for="allow_streaming_opt_out" class="form-check-label">
+    Streaming opt out: Allow players to choose whether their games should be
+    included in video coverage (defaults to yes, and players are notified that
+    in a top cut it may not be possible to exclude them)
+  </label>
+</div>
+
+{#if featureFlags.allow_self_reporting}
+  <div class="form-check mb-3">
+    <input
+      type="checkbox"
+      id="allow_self_reporting"
+      class="form-check-input"
+      bind:checked={tournamentEdit.allow_self_reporting}
+    />
+    <label for="allow_self_reporting" class="form-check-label">
+      Allow logged-in players to report their own match results
+    </label>
+  </div>
+{/if}
+
+<ProgressButton
+  css="btn btn-primary"
+  inProgressText="Saving"
+  completeText="Saved"
+  onclick={() => {
+    return onSubmitCallback ? onSubmitCallback(tournamentEdit) : false;
+  }}
+>
+  <FontAwesomeIcon icon={submitIcon} />
+  {submitLabel}
+</ProgressButton>

--- a/frontend/src/routes/tournaments/TournamentSettingsForm.svelte
+++ b/frontend/src/routes/tournaments/TournamentSettingsForm.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
   import ProgressButton from "$lib/components/ProgressButton.svelte";
-  import { emptyTournamentOptions, swissFormatDisplayString, type FeatureFlags, type Tournament, type TournamentOptions } from "$lib/model/Tournament";
+  import {
+    emptyTournamentOptions,
+    swissFormatDisplayString,
+    type FeatureFlags,
+    type Tournament,
+    type TournamentOptions,
+  } from "$lib/model/Tournament";
   import { type Errors } from "$lib/utils/errors";
 
   let {
@@ -28,12 +34,7 @@
 
 <div class="form-group">
   <label for="name"><abbr title="required">*</abbr> Tournament name</label>
-  <input
-    type="text"
-    id="name"
-    class="form-control"
-    bind:value={tournamentEdit.name}
-  />
+  <input type="text" id="name" class="form-control" bind:value={tournamentEdit.name} />
   {#if errors.name}
     <div class="invalid-feedback d-block">{errors.name}</div>
   {/if}
@@ -43,12 +44,7 @@
   <div class="col-md-6">
     <div class="form-group">
       <label for="date">Date</label>
-      <input
-        type="date"
-        id="date"
-        class="form-control"
-        bind:value={tournamentEdit.date}
-      />
+      <input type="date" id="date" class="form-control" bind:value={tournamentEdit.date} />
       {#if errors.date}
         <div class="invalid-feedback d-block">{errors.date}</div>
       {/if}
@@ -57,11 +53,7 @@
   <div class="col-md-6">
     <div class="form-group">
       <label for="time_zone">Time zone</label>
-      <select
-        id="time_zone"
-        class="form-control"
-        bind:value={tournamentEdit.time_zone}
-      >
+      <select id="time_zone" class="form-control" bind:value={tournamentEdit.time_zone}>
         {#each options.time_zones as time_zone (time_zone.id)}
           <option value={time_zone.id}>{time_zone.name}</option>
         {/each}
@@ -106,11 +98,7 @@
 
 <div class="form-group">
   <label for="swiss_format">Swiss format</label>
-  <select
-    id="swiss_format"
-    class="form-control"
-    bind:value={tournamentEdit.swiss_format}
-  >
+  <select id="swiss_format" class="form-control" bind:value={tournamentEdit.swiss_format}>
     <option value="double_sided">{swissFormatDisplayString("double_sided")}</option>
     <option value="single_sided">{swissFormatDisplayString("single_sided")}</option>
   </select>
@@ -141,11 +129,7 @@
   <div class="col-md-6">
     <div class="form-group">
       <label for="card_set_id">Legal Cardpool Up To</label>
-      <select
-        id="card_set_id"
-        class="form-control"
-        bind:value={tournamentEdit.card_set_id}
-      >
+      <select id="card_set_id" class="form-control" bind:value={tournamentEdit.card_set_id}>
         <option value=""></option>
         {#each options.card_sets as card_set (card_set.id)}
           <option value={card_set.id}>{card_set.name}</option>
@@ -162,11 +146,7 @@
   <div class="col-md-6">
     <div class="form-group">
       <label for="format_id">Play Format</label>
-      <select
-        id="format_id"
-        class="form-control"
-        bind:value={tournamentEdit.format_id}
-      >
+      <select id="format_id" class="form-control" bind:value={tournamentEdit.format_id}>
         <option value=""></option>
         {#each options.formats as format (format.id)}
           <option value={format.id}>{format.name}</option>
@@ -206,9 +186,7 @@
     class="form-check-input"
     bind:checked={tournamentEdit.decklist_required}
   />
-  <label for="decklist_required" class="form-check-label">
-    Decklist required for event
-  </label>
+  <label for="decklist_required" class="form-check-label"> Decklist required for event </label>
 </div>
 
 <div class="form-group">
@@ -226,12 +204,7 @@
 
 <div class="form-group">
   <label for="event_link">External Event Link</label>
-  <input
-    type="url"
-    id="event_link"
-    class="form-control"
-    bind:value={tournamentEdit.event_link}
-  />
+  <input type="url" id="event_link" class="form-control" bind:value={tournamentEdit.event_link} />
   {#if errors.event_link}
     <div class="invalid-feedback d-block">{errors.event_link}</div>
   {/if}
@@ -239,10 +212,7 @@
 
 <div class="form-group">
   <label for="description">Event Description (Markdown format supported)</label>
-  <textarea
-    id="description"
-    class="form-control"
-    bind:value={tournamentEdit.description}
+  <textarea id="description" class="form-control" bind:value={tournamentEdit.description}
   ></textarea>
   {#if errors.description}
     <div class="invalid-feedback d-block">{errors.description}</div>
@@ -273,8 +243,7 @@
   <textarea
     id="additional_prizes_description"
     class="form-control"
-    bind:value={tournamentEdit.additional_prizes_description}
-  ></textarea>
+    bind:value={tournamentEdit.additional_prizes_description}></textarea>
   {#if errors.additional_prizes_description}
     <div class="invalid-feedback d-block">
       {errors.additional_prizes_description}
@@ -284,12 +253,7 @@
 
 <div class="form-group">
   <label for="stream_url">Stream URL</label>
-  <input
-    type="url"
-    id="stream_url"
-    class="form-control"
-    bind:value={tournamentEdit.stream_url}
-  />
+  <input type="url" id="stream_url" class="form-control" bind:value={tournamentEdit.stream_url} />
   {#if errors.stream_url}
     <div class="invalid-feedback d-block">{errors.stream_url}</div>
   {/if}
@@ -339,9 +303,8 @@
     bind:checked={tournamentEdit.manual_seed}
   />
   <label for="manual_seed" class="form-check-label">
-    Use manual seeding for tiebreakers: Players can be assigned a "seed" value
-    that will be used before all other tiebreakers (in ascending order; i.e.
-    Seed 1 wins all ties)
+    Use manual seeding for tiebreakers: Players can be assigned a "seed" value that will be used
+    before all other tiebreakers (in ascending order; i.e. Seed 1 wins all ties)
   </label>
 </div>
 
@@ -353,9 +316,9 @@
     bind:checked={tournamentEdit.allow_streaming_opt_out}
   />
   <label for="allow_streaming_opt_out" class="form-check-label">
-    Streaming opt out: Allow players to choose whether their games should be
-    included in video coverage (defaults to yes, and players are notified that
-    in a top cut it may not be possible to exclude them)
+    Streaming opt out: Allow players to choose whether their games should be included in video
+    coverage (defaults to yes, and players are notified that in a top cut it may not be possible to
+    exclude them)
   </label>
 </div>
 

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -32,7 +32,7 @@ export async function loadTournaments(url: string, altFetch = fetch): Promise<To
     if (!response.ok) {
       throw new Error("Network response was not ok");
     }
-    
+
     return (await response.json()) as TournamentsResponse;
   } catch (e) {
     const err = e as Error;
@@ -40,7 +40,7 @@ export async function loadTournaments(url: string, altFetch = fetch): Promise<To
   }
 
   return {
-    data: []
+    data: [],
   };
 }
 
@@ -58,16 +58,16 @@ export function tournamentsApiUrl(tournamentTypeId?: string): string {
   return query.join("&");
 }
 
-export async function loadNewTournament(fetch: typeof globalThis.fetch): Promise<TournamentSettingsData> {
+export async function loadNewTournament(
+  fetch: typeof globalThis.fetch,
+): Promise<TournamentSettingsData> {
   const response = await fetch(`${COBRA_API_SERVER}/tournaments/new_form`, {
     credentials: "include",
     headers: { Accept: "application/json" },
     method: "GET",
   });
   if (!response.ok) {
-    throw new Error(
-      `HTTP ${response.status.toString()}: ${response.statusText}`,
-    );
+    throw new Error(`HTTP ${response.status.toString()}: ${response.statusText}`);
   }
 
   return (await response.json()) as TournamentSettingsData;
@@ -90,13 +90,10 @@ export async function createTournament(
 
   if (!response.ok) {
     if (response.status === 422) {
-      const errorData =
-        (await response.json()) as TournamentCreateErrorResponse;
+      const errorData = (await response.json()) as TournamentCreateErrorResponse;
       throw new ValidationError(errorData.errors);
     }
-    throw new Error(
-      `HTTP ${response.status.toString()}: ${response.statusText}`,
-    );
+    throw new Error(`HTTP ${response.status.toString()}: ${response.statusText}`);
   }
 
   return (await response.json()) as TournamentCreateResponse;

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -1,6 +1,25 @@
 import { COBRA_API_SERVER } from "$app/env/public";
+import type { FeatureFlags, Tournament, TournamentOptions } from "$lib/model/Tournament";
 import type { TournamentsResponse } from "$lib/utils/api_types";
+import { ValidationError, type Errors } from "$lib/utils/errors";
 import { globalMessages } from "$lib/utils/GlobalMessageState.svelte";
+
+export interface TournamentSettingsData {
+  tournament: Tournament;
+  options: TournamentOptions;
+  feature_flags: FeatureFlags;
+  csrf_token: string;
+}
+
+export interface TournamentCreateResponse {
+  id: number;
+  name: string;
+  url: string;
+}
+
+export interface TournamentCreateErrorResponse {
+  errors: Errors;
+}
 
 export async function loadTournaments(url: string, altFetch = fetch): Promise<TournamentsResponse> {
   try {
@@ -37,4 +56,48 @@ export function tournamentsApiUrl(tournamentTypeId?: string): string {
   }
 
   return query.join("&");
+}
+
+export async function loadNewTournament(fetch: typeof globalThis.fetch): Promise<TournamentSettingsData> {
+  const response = await fetch(`${COBRA_API_SERVER}/tournaments/new_form`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+    method: "GET",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status.toString()}: ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as TournamentSettingsData;
+}
+
+export async function createTournament(
+  csrfToken: string,
+  tournament: Tournament,
+): Promise<TournamentCreateResponse> {
+  const response = await fetch(`${COBRA_API_SERVER}/tournaments`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Accept: "application/vnd.api+json",
+      "Content-Type": "application/vnd.api+json",
+      "X-CSRF-Token": csrfToken,
+    },
+    body: JSON.stringify({ tournament }),
+  });
+
+  if (!response.ok) {
+    if (response.status === 422) {
+      const errorData =
+        (await response.json()) as TournamentCreateErrorResponse;
+      throw new ValidationError(errorData.errors);
+    }
+    throw new Error(
+      `HTTP ${response.status.toString()}: ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as TournamentCreateResponse;
 }

--- a/frontend/src/routes/tournaments/demo/+page.svelte
+++ b/frontend/src/routes/tournaments/demo/+page.svelte
@@ -5,10 +5,10 @@
     type Errors,
     loadNewDemoTournament,
     type DemoTournamentSettings,
-    ValidationError,
     navigateTo,
   } from "./DemoTournamentSettings";
   import DemoTournamentSettingsForm from "./DemoTournamentSettingsForm.svelte";
+  import { ValidationError } from "$lib/utils/errors";
 
   let tournament = $state<DemoTournamentSettings | undefined>(undefined);
   let csrfToken = "";

--- a/frontend/src/routes/tournaments/demo/DemoTournamentCreation.svelte.test.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentCreation.svelte.test.ts
@@ -2,11 +2,11 @@ import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/sv
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import DemoTournamentCreation from "./+page.svelte";
 import {
-  ValidationError,
   loadNewDemoTournament,
   createDemoTournament,
   navigateTo,
 } from "./DemoTournamentSettings";
+import { ValidationError } from "$lib/utils/errors";
 
 // Mock the DemoTournamentSettings module
 vi.mock("./DemoTournamentSettings", () => {

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   loadNewDemoTournament,
   createDemoTournament,
-  ValidationError,
 } from "./DemoTournamentSettings";
+import { ValidationError } from "$lib/utils/errors";
 
 describe("DemoTournamentSettings", () => {
   beforeEach(() => {

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettings.ts
@@ -1,4 +1,5 @@
 import { COBRA_API_SERVER } from "$app/env/public";
+import { ValidationError } from "$lib/utils/errors";
 
 export type Errors = Record<string, string[]>;
 
@@ -77,13 +78,6 @@ export async function createDemoTournament(
   }
 
   return (await response.json()) as TournamentDemoCreateResponse;
-}
-
-export class ValidationError extends Error {
-  constructor(public errors: Errors) {
-    super("Validation failed");
-    this.name = "ValidationError";
-  }
 }
 
 export function navigateTo(url: string) {

--- a/frontend/src/routes/tournaments/demo/DemoTournamentSettingsForm.svelte
+++ b/frontend/src/routes/tournaments/demo/DemoTournamentSettingsForm.svelte
@@ -5,16 +5,7 @@
   } from "./DemoTournamentSettings";
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
   import ProgressButton from "$lib/components/ProgressButton.svelte";
-
-  // TODO(plural): Replace with appropriate library.
-  function swissFormatDisplayString(format: string) {
-    if (format === "single_sided") {
-      return "Single-sided";
-    } else if (format === "double_sided") {
-      return "Double-sided";
-    }
-    return "Unknown";
-  }
+  import { swissFormatDisplayString } from "$lib/model/Tournament";
 
   let {
     tournament,

--- a/frontend/src/routes/tournaments/my/+page.svelte
+++ b/frontend/src/routes/tournaments/my/+page.svelte
@@ -3,6 +3,7 @@
   import { authStore, type AuthUser } from "$lib/utils/auth.svelte";
   import { COBRA_API_SERVER } from "$app/env/public";
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import { resolve } from "$app/paths";
 
   interface Tournament {
     id: number;
@@ -84,7 +85,7 @@
         <h2>My Tournaments</h2>
         <p class="text-muted mb-0">Logged in as <strong>{user.nrdb_username}</strong></p>
       </div>
-      <a href={`${serverOrigin}/tournaments/new`} rel="external" class="btn btn-success">
+      <a href={resolve("/tournaments/new")} rel="external" class="btn btn-success">
         <FontAwesomeIcon icon="plus" /> New Tournament
       </a>
     </div>

--- a/frontend/src/routes/tournaments/new/+page.svelte
+++ b/frontend/src/routes/tournaments/new/+page.svelte
@@ -21,7 +21,10 @@
       } else {
         errors = { base: ["An unexpected error occurred. Please try again."] };
       }
-      errors = error instanceof ValidationError ? error.errors : { base: ["An unexpected error occurred. Please try again."] };
+      errors =
+        error instanceof ValidationError
+          ? error.errors
+          : { base: ["An unexpected error occurred. Please try again."] };
 
       return false;
     }

--- a/frontend/src/routes/tournaments/new/+page.svelte
+++ b/frontend/src/routes/tournaments/new/+page.svelte
@@ -33,7 +33,6 @@
   }
 </script>
 
-<!-- TODO: Do we need/want these extra divs? -->
 <div>
   <h1>Create a tournament</h1>
 

--- a/frontend/src/routes/tournaments/new/+page.svelte
+++ b/frontend/src/routes/tournaments/new/+page.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { PageProps } from "./$types";
+  import TournamentSettingsForm from "../TournamentSettingsForm.svelte";
+  import type { Tournament } from "$lib/model/Tournament";
+  import { type Errors, ValidationError } from "$lib/utils/errors";
+  import { createTournament } from "../api_helper";
+
+  let { data }: PageProps = $props();
+
+  let errors = $state<Errors>({});
+
+  async function submitNewTournament(tournament: Tournament) {
+    errors = {};
+
+    try {
+      const response = await createTournament(data.tournamentSettings.csrf_token, tournament);
+      window.location.href = response.url;
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        errors = error.errors;
+      } else {
+        errors = { base: ["An unexpected error occurred. Please try again."] };
+      }
+      errors = error instanceof ValidationError ? error.errors : { base: ["An unexpected error occurred. Please try again."] };
+
+      return false;
+    }
+
+    return true;
+  }
+</script>
+
+<!-- TODO: Do we need/want these extra divs? -->
+<div>
+  <h1>Create a tournament</h1>
+
+  {#if errors.base}
+    <div class="alert alert-danger">{errors.base}</div>
+  {:else if data.tournamentSettings.tournament}
+    <TournamentSettingsForm
+      tournament={data.tournamentSettings.tournament}
+      options={data.tournamentSettings.options}
+      featureFlags={data.tournamentSettings.feature_flags}
+      onSubmitCallback={submitNewTournament}
+      submitLabel="Create"
+      submitIcon="plus"
+      {errors}
+    />
+  {:else}
+    <div class="d-flex align-items-center m-2" data-testid="loading-spinner">
+      <div class="spinner-border m-auto"></div>
+    </div>
+  {/if}
+</div>

--- a/frontend/src/routes/tournaments/new/+page.ts
+++ b/frontend/src/routes/tournaments/new/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from "./$types";
+import { loadNewTournament } from "../api_helper";
+
+export const load: PageLoad = async ({ fetch }: { fetch: typeof globalThis.fetch}) => {
+  return {
+    tournamentSettings: await loadNewTournament(fetch),
+  };
+}

--- a/frontend/src/routes/tournaments/new/+page.ts
+++ b/frontend/src/routes/tournaments/new/+page.ts
@@ -1,8 +1,8 @@
 import type { PageLoad } from "./$types";
 import { loadNewTournament } from "../api_helper";
 
-export const load: PageLoad = async ({ fetch }: { fetch: typeof globalThis.fetch}) => {
+export const load: PageLoad = async ({ fetch }: { fetch: typeof globalThis.fetch }) => {
   return {
     tournamentSettings: await loadNewTournament(fetch),
   };
-}
+};

--- a/frontend/src/routes/tournaments/new/TournamentCreation.svelte.test.ts
+++ b/frontend/src/routes/tournaments/new/TournamentCreation.svelte.test.ts
@@ -1,0 +1,212 @@
+import { Tournament } from "$lib/model/Tournament";
+import { ValidationError } from "$lib/utils/errors";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TournamentCreation from "./+page.svelte";
+
+// Mock the TournamentSettings module
+vi.mock("../api_helper", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api_helper")>()),
+  loadNewTournament: vi.fn(),
+  createTournament: vi.fn(),
+}));
+
+describe("TournamentCreation", () => {
+  const mockTournamentData = {
+    tournament: new Tournament({
+      date: "2023-12-25",
+      private: false,
+      swiss_format: "double_sided",
+      allow_self_reporting: false,
+      decklist_required: false,
+      nrdb_deck_registration: false,
+    }),
+    options: {
+      tournament_types: [{ id: 1, name: "Store Championship" }],
+      formats: [{ id: 1, name: "Standard" }],
+      card_sets: [{ id: 1, name: "System Gateway" }],
+      deckbuilding_restrictions: [{ id: 1, name: "Standard Ban List" }],
+      time_zones: [{ id: "UTC", name: "(GMT+00:00) UTC" }],
+      official_prize_kits: [{ id: 1, name: "2025 Q1 Game Night Kit" }],
+    },
+    feature_flags: {
+      single_sided_swiss: true,
+      nrdb_deck_registration: true,
+      allow_self_reporting: true,
+      streaming_opt_out: true,
+    },
+    csrf_token: "fake-csrf-token",
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Mock loadNewTournament to return test data
+    const { loadNewTournament } = await import("../api_helper");
+    vi.mocked(loadNewTournament).mockResolvedValue(mockTournamentData);
+  });
+
+  it("renders the tournament creation form", async () => {
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create a tournament")).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+
+  it("loads initial tournament data on mount", async () => {
+    const { loadNewTournament } = await import("../api_helper");
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(loadNewTournament).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows a loading spinner", async () => {
+    const { loadNewTournament } = await import("../api_helper");
+    vi.mocked(loadNewTournament).mockImplementation(
+      () =>
+        new Promise(() => {
+          // This promise intentionally never resolves to test loading state
+        }),
+    );
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByText("Create a tournament")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/tournament name/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  });
+
+  it("successfully creates a tournament", async () => {
+    const { createTournament } = await import("../api_helper");
+    const mockResponse = {
+      id: 123,
+      name: "Test Tournament",
+      url: "/tournaments/123",
+    };
+    vi.mocked(createTournament).mockResolvedValue(mockResponse);
+
+    // Mock window.location.href
+    const mockLocation = { href: "" };
+    Object.defineProperty(window, "location", {
+      value: mockLocation,
+      writable: true,
+    });
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    // Fill in the form
+    const nameInput = screen.getByLabelText(/tournament name/i);
+    await fireEvent.input(nameInput, { target: { value: "Test Tournament" } });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(createTournament).toHaveBeenCalledWith(
+        "fake-csrf-token",
+        expect.objectContaining({
+          name: "Test Tournament",
+        }),
+      );
+    });
+
+    // Check that redirect happens
+    await waitFor(() => {
+      expect(mockLocation.href).toBe("/tournaments/123");
+    });
+  });
+
+  it("handles validation errors", async () => {
+    const { createTournament } = await import("../api_helper");
+    const validationError = new ValidationError({
+      name: ["Name is required"],
+      date: ["Date must be in the future"],
+    });
+    vi.mocked(createTournament).mockRejectedValue(validationError);
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument();
+      expect(
+        screen.getByText("Date must be in the future"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("handles unexpected errors", async () => {
+    const { createTournament } = await import("../api_helper");
+    vi.mocked(createTournament).mockRejectedValue(new Error("Network error"));
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    // Submit the form
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/an unexpected error occurred/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("disables submit button while submitting", async () => {
+    const { createTournament } = await import("../api_helper");
+    // Make createTournament hang to test loading state
+    vi.mocked(createTournament).mockImplementation(
+      () =>
+        new Promise(() => {
+          // This promise intentionally never resolves to test loading state
+        }),
+    );
+
+    render(TournamentCreation);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/tournament name/i)).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    await fireEvent.click(submitButton);
+
+    // Button should be disabled while submitting
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
This adds the create (non-demo) tournament page to the SPA. There is nothing weird here, and with the same test caveat as the other pages (I've copied the file over but we still need to figure out the Playwright config).

The only two noteworthy things are:
1. `ValidationError` in DemoTournamentSettings.ts was moved to frontend/src/lib/utils/errors.ts.
2.  `swissFormatDisplayString()` in DemoTournamentSettingsForm.ts was moved to frontend/src/lib/model/Tournament.ts.