### PR TITLE
Update tournament layout and nav, with active checks for tabs.

### DIFF
--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import type { Snippet } from "svelte";
   import type { LayoutData } from "./$types";
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
@@ -8,8 +9,6 @@
   let { children, data }: { children: Snippet; data: LayoutData; } = $props();
 
   let canEdit = $derived(data.tournament.user_id === authStore.user?.id);
-  // TODO: Determine this properly
-  let canDestroy = $derived(true);
 </script>
 
 <style>
@@ -18,7 +17,6 @@
   }
 </style>
 
-<div class="container">
   <!-- Tournament header -->
   <div class="row dontprint">
     <div class="col-md">
@@ -41,61 +39,97 @@
   <ul class="nav nav-tabs dontprint">
     <!-- TODO: Set active class on all tabs -->
     
-    <!-- TODO: Display if show? -->
     <li class="nav-item">
-      <a href={resolve(`/tournaments/${data.tournament.id}`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}`)}
+        class="nav-link"
+        class:active={page.route.id === "/tournaments/[tournamentId]"}
+      >
         <FontAwesomeIcon icon="trophy" /> Tournament
       </a>
     </li>
-    <!-- TODO: Display if show? -->
+    
+    <!-- TODO: Remove the 'as string' casts throughout once the route id exists. -->
     {#if data.player}
       <li class="nav-item">
-        <a href={resolve(`/tournaments/${data.tournament.id}/my_tournament`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/my_tournament`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/my_tournament"}
+      >
           <FontAwesomeIcon icon="user" /> Me
         </a>
       </li>
     {/if}
     {#if canEdit}
       <li class="nav-item">
-        <a href={resolve(`/tournaments/${data.tournament.id}/players`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/players`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/players"}
+      >
           <FontAwesomeIcon icon="users" /> Players
         </a>
       </li>
     {/if}
     <!-- TODO: Display If show? -->
     <li class="nav-item">
-      <a href={resolve(`/tournaments/${data.tournament.id}/rounds`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/rounds`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/rounds"}
+      >
         <FontAwesomeIcon icon="calendar-check-o" /> Pairings
       </a>
     </li>
     <!-- TODO: Display if show? -->
     <li class="nav-item">
-      <a href={resolve(`/tournaments/${data.tournament.id}/standings`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/players/standings`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/players/standings"}
+      >
         <FontAwesomeIcon icon="list-ol" /> Standings
       </a>
     </li>
-    <!-- TODO: Display if show? and any elimination stages -->
+    <!-- TODO: Display if there is an elimination stage. -->
     <li class="nav-item">
-      <a href={resolve(`/tournaments/${data.tournament.id}/bracket`)} class="nav-link">
+    <a
+      href={resolve(`/tournaments/${data.tournament.id}/bracket`)}
+      class="nav-link"
+      class:active={page.route.id as string === "/tournaments/[tournamentId]/bracket"}
+    >
         <FontAwesomeIcon icon="sitemap" /> Bracket
       </a>
     </li>
     <!-- TODO: Display if show? -->
     <li class="nav-item">
-      <a href={resolve(`/tournaments/${data.tournament.id}/stats`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/stats`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/stats"}
+      >
         <FontAwesomeIcon icon="pie-chart" /> Stats
       </a>
     </li>
     {#if canEdit}
       <li class="nav-item">
-        <a href={resolve(`/tournaments/${data.tournament.id}/edit`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/edit`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/edit"}
+      >
           <FontAwesomeIcon icon="cog" /> Settings
         </a>
       </li>
     {/if}
-    {#if canDestroy}
+    {#if canEdit}
       <li class="nav-item">
-        <a href={resolve(`/tournaments/${data.tournament.id}/danger_zone`)} class="nav-link">
+      <a
+        href={resolve(`/tournaments/${data.tournament.id}/danger_zone`)}
+        class="nav-link"
+        class:active={page.route.id as string === "/tournaments/[tournamentId]/danger_zone"}
+      >
           <FontAwesomeIcon icon="trash" /> Danger Zone
         </a>
       </li>
@@ -106,4 +140,3 @@
   <div class="row py-3 main-content">
     {@render children()}
   </div>
-</div>

--- a/frontend/src/routes/tournaments/[tournamentId]/+page.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/+page.svelte
@@ -198,59 +198,53 @@
       </div>
       <!-- Registration -->
       <div class="col-md-6" aria-label="registration information">
-        {#if data.player}
-          {#if data.player.id !== 0}
-            {#if data.player.active}
-              <!-- User is logged in and registered -->
-              <RegistrationCard {userId} tournament={data.tournament} player={data.player} />
-            {:else}
-              <!-- User is logged in and registered but dropped -->
-              <h5 class="card-title">Rejoin this Event</h5>
-              {#if userId === data.tournament.user_id}
-                <p>
-                  You can reinstate yourself on the
-                  <a href={resolve(`/tournaments/${data.tournament.id}/players`)}>
-                    Players
-                  </a>
-                  tab.
-                </p>
-              {:else}
-                <p>Talk to a Tournament Organiser to rejoin the event.</p>
-              {/if}
-            {/if}
-          {:else if !data.tournament.registration_closed && data.tournament.self_registration}
-            {#if userId != -1}
-              <!-- User is logged in and not registered -->
-              <RegistrationCard {userId} tournament={data.tournament} player={data.player} />
-            {:else}
-              <!-- User is not logged in and not registered -->
-              <div class="card card-body alert alert-warning">
-                <h5 class="card-title">Register for this Event</h5>
-
-                <p class="mb-1">
-                  You must be logged in to register for this tournament:
-                </p>
-                <a
-                  class="alert-link"
-                  href={resolve(`/login?return_to=/tournaments/${data.tournament.id}`)}
-                >
-                  <FontAwesomeIcon icon="sign-in" /> Sign in
+        {#if data.player && data.player.id !== 0}
+          {#if data.player.active}
+            <!-- User is logged in and registered -->
+            <RegistrationCard {userId} tournament={data.tournament} player={data.player} />
+          {:else}
+            <!-- User is logged in and registered but dropped -->
+            <h5 class="card-title">Rejoin this Event</h5>
+            {#if userId === data.tournament.user_id}
+              <p>
+                You can reinstate yourself on the
+                <a href={resolve(`/tournaments/${data.tournament.id}/players`)}>
+                  Players
                 </a>
-
-                <p class="mt-4 mb-1">
-                  Don't have an account? Register with NetrunnerDB, then return
-                  to Cobra to log in:
-                </p>
-                <a class="alert-link" href="https://netrunnerdb.com/register/">
-                  <i class="icon icon-link"></i> Create NRDB Account
-                </a>
-              </div>
+                tab.
+              </p>
+            {:else}
+              <p>Talk to a Tournament Organiser to rejoin the event.</p>
             {/if}
           {/if}
-        {:else}
-          <div class="d-flex align-items-center m-2">
-            <div class="spinner-border m-auto"></div>
-          </div>
+        {:else if !data.tournament.registration_closed && data.tournament.self_registration}
+          {#if authStore.isAuthenticated && data.player}
+            <!-- User is logged in and not registered -->
+            <RegistrationCard {userId} tournament={data.tournament} player={data.player} />
+          {:else}
+            <!-- User is not logged in and not registered -->
+            <div class="card card-body alert alert-warning">
+              <h5 class="card-title">Register for this Event</h5>
+
+              <p class="mb-1">
+                You must be logged in to register for this tournament:
+              </p>
+              <a
+                class="alert-link"
+                href={resolve(`/login?return_to=/tournaments/${data.tournament.id}`)}
+              >
+                <FontAwesomeIcon icon="sign-in" /> Sign in
+              </a>
+
+              <p class="mt-4 mb-1">
+                Don't have an account? Register with NetrunnerDB, then return
+                to Cobra to log in:
+              </p>
+              <a class="alert-link" href="https://netrunnerdb.com/register/">
+                <i class="icon icon-link"></i> Create NRDB Account
+              </a>
+            </div>
+          {/if}
         {/if}
       </div>
     </div>


### PR DESCRIPTION
This does 2 things:

* Removes an extra container div that was squishing the contents.
* Sets the active class for the tabs on tournament view.

## Logged Out

### Self-registration on
<img width="1152" height="907" alt="Screenshot 2026-08-16 at 9 56 37 AM" src="https://github.com/user-attachments/assets/496013ec-518f-4ac9-bc20-658c62a2c2ed" />

### Self-registration off
<img width="1144" height="731" alt="Screenshot 2026-08-16 at 10 01 57 AM" src="https://github.com/user-attachments/assets/4bc22d5d-04f6-4dfd-946a-06e325593a91" />


## Logged In

### Self-registration on
<img width="1162" height="1041" alt="Screenshot 2026-08-16 at 9 57 09 AM" src="https://github.com/user-attachments/assets/0b2f6734-6340-446a-87b6-97c4b981d8df" />

### Self-registration off
<img width="1158" height="716" alt="Screenshot 2026-08-15 at 11 54 06 PM" src="https://github.com/user-attachments/assets/24fe3055-56ce-45cb-b1a1-e0b654ae0575" />


