### PR TITLE
Move the playwright setup to the Dockerfile.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,32 @@
+# Pull official Playwright image matching your playwright version with all 3 browsers (chromium, webkit, firefox)
+FROM mcr.microsoft.com/playwright:v1.62.0-noble AS playwright-browsers
+
 FROM mcr.microsoft.com/devcontainers/ruby:3.4-bookworm
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
 # The value is a comma-separated list of allowed domains
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# Install Playwright browser dependencies (Chromium, Firefox, WebKit) and other necessary packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+       libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+       libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 \
+       libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+       libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 \
+       libxrender1 libxss1 libxtst6 zlib1g libnss3 libxshmfence1 libegl1 libgles2 \
+       libvpx7 libevent-2.1-7 libopus0 libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
+       libgstreamer-gl1.0-0 libflite1 libwoff1 libharfbuzz-icu0 libsecret-1-0 libhyphen0 \
+       libmanette-0.2-0 libgles2-mesa \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Pre-install matching Bundler version and Ruby LSP
 RUN gem install "bundler:>= 4.0.9" ruby-lsp
+
+# Configure Playwright shared browsers path and copy pre-installed browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+COPY --from=playwright-browsers /ms-playwright /ms-playwright
+RUN chmod -R 777 /ms-playwright
 
 # Ensure volume mount directories and RVM gem directories are writable by the vscode user
 RUN mkdir -p /home/vscode/.bundle /commandhistory \
@@ -20,6 +37,3 @@ RUN mkdir -p /home/vscode/.bundle /commandhistory \
 ENV GEM_HOME="/home/vscode/.bundle"
 ENV GEM_PATH="/home/vscode/.bundle:/usr/local/rvm/gems/default:/usr/local/rvm/gems/default@global"
 ENV PATH="/home/vscode/.bundle/bin:${PATH}"
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
         "GEM_HOME": "/home/vscode/.bundle",
         "GEM_PATH": "/home/vscode/.bundle:/usr/local/rvm/gems/default:/usr/local/rvm/gems/default@global",
         "BUNDLE_PATH": "/home/vscode/.bundle",
-        "BUNDLE_APP_CONFIG": "/home/vscode/.bundle"
+        "BUNDLE_APP_CONFIG": "/home/vscode/.bundle",
+        "PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright"
     },
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
@@ -35,8 +36,7 @@
     // This can be used to network with other containers or the host.
     "forwardPorts": [
         3000,
-        5173,
-        5432
+        5173
     ],
     "portsAttributes": {
         "3000": {
@@ -48,13 +48,18 @@
             "onAutoForward": "notify"
         }
     },
+    // Ignore automatic forwarding for unlisted/ephemeral ports (like browser debugging sockets)
+    "otherPortsAttributes": {
+        "onAutoForward": "ignore"
+    },
     // Use 'postCreateCommand' to run commands after the container is created and volumes are mounted.
-    "postCreateCommand": "cp -n config/database.example.app-in-docker.yml config/database.yml 2>/dev/null || true && bundle install && bundle exec rails db:prepare && npm install && cd frontend && npm install && npx playwright install-deps && npx playwright install",
+    "postCreateCommand": "cp -n config/database.example.app-in-docker.yml config/database.yml 2>/dev/null || true && bundle install && bundle exec rails db:prepare && npm install && cd frontend && npm install",
     // Configure tool-specific properties.
     "customizations": {
         "vscode": {
             // Set *default* container specific settings.json values on container create.
             "settings": {
+                "remote.autoForwardPorts": false,
                 "editor.formatOnSave": false,
                 "emmet.includeLanguages": {
                     "erb": "html"


### PR DESCRIPTION
This removes some setup time by moving the browser download to the docker level instead of inside the container after starting up.