### PR TITLE
SPA - Round timer

### DIFF
--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -4,7 +4,7 @@ module Beta
   class TournamentsController < ApplicationController # rubocop:disable Metrics/ClassLength,Style/Documentation
     before_action :set_tournament, only: %i[
       show update info qr registration open_registration close_registration lock_player_registrations
-      unlock_player_registrations cut stats id_and_faction_data cut_conversion_rates
+      unlock_player_registrations cut stats id_and_faction_data cut_conversion_rates current_round_timer
     ]
     before_action :authorize_beta_testing
 
@@ -193,6 +193,19 @@ module Beta
       authorize @tournament, :show?
 
       render json: transform_cut_stats(@tournament.cut_conversion_rates_data)
+    end
+
+    def current_round_timer
+      authorize @tournament, :show?
+
+      current_round = @tournament.rounds&.last
+
+      render json: {
+        running: current_round&.timer&.running?,
+        paused: current_round&.timer&.paused?,
+        started: current_round&.timer&.started?,
+        state: current_round.timer&.state
+      }
     end
 
     private

--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -201,6 +201,7 @@ module Beta
       current_round = @tournament.rounds&.last
 
       render json: {
+        show: current_round&.timer&.show?,
         running: current_round&.timer&.running?,
         paused: current_round&.timer&.paused?,
         started: current_round&.timer&.started?,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
       get :stats, on: :member
       get :id_and_faction_data, on: :member
       get :cut_conversion_rates, on: :member
+      get :current_round_timer, on: :member
     end
     resources :identities, only: [:index]
   end

--- a/frontend/src/lib/components/ModalDialog.svelte
+++ b/frontend/src/lib/components/ModalDialog.svelte
@@ -2,14 +2,19 @@
   import type { Snippet } from "svelte";
   import FontAwesomeIcon from "./FontAwesomeIcon.svelte";
 
-  interface Props {
+  let {
+    id,
+    headerText,
+    dialogClass,
+    children,
+    footer
+  }: {
     id: string;
     headerText: string;
+    dialogClass?: string;
     children?: Snippet;
     footer?: Snippet;
-  }
-
-  let { id, headerText, children, footer }: Props = $props();
+  } = $props();
 
   function portal(node: HTMLElement) {
     document.body.appendChild(node);
@@ -24,7 +29,7 @@
 </script>
 
 <div {id} class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" use:portal>
-  <div class="modal-dialog modal-dialog-centered" role="document">
+  <div class="modal-dialog modal-dialog-centered {dialogClass}" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h4>{headerText}</h4>

--- a/frontend/src/lib/model/Round.ts
+++ b/frontend/src/lib/model/Round.ts
@@ -1,0 +1,13 @@
+export interface RoundTimer {
+  show: boolean;
+  running: boolean;
+  paused: boolean;
+  started: boolean;
+  state: {
+    started: boolean;
+    paused: boolean;
+    finish_time?: string;
+    remaining_seconds?: number;
+    length_minutes?: number;
+  }
+}

--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
@@ -5,6 +5,7 @@
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
   import { resolve } from "$app/paths";
   import { authStore } from "$lib/utils/auth.svelte";
+  import RoundTimer from "./RoundTimer.svelte";
 
   let { children, data }: { children: Snippet; data: LayoutData; } = $props();
 
@@ -40,9 +41,11 @@
       </a>
     </div>
   {/if}
-  <div class="col col-md-auto mb-md-0 mb-2">
-    <!-- TODO: Round timer -->
-  </div>
+  {#if data.timer.show}
+    <div class="col col-md-auto mb-md-0 mb-2">
+      <RoundTimer timer={data.timer} />
+    </div>
+  {/if}
 </div>
 
 <!-- Tabs -->

--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.ts
@@ -6,9 +6,11 @@ export const load: LayoutLoad = async ({ params, fetch }) => {
   const user = await authStore.checkAuth(fetch);
   const tournamentId = parseInt(params.tournamentId);
 
+  const tournament = await loadTournament(tournamentId, fetch);
+
   return {
-    tournamentData: await loadTournament(tournamentId, fetch),
-    timer: loadCurrentRoundTimer(tournamentId),
+    tournamentData: tournament,
+    timer: await loadCurrentRoundTimer(tournamentId, tournament.csrf_token),
     player: user ? await loadPlayerByUserId(tournamentId, user.id, fetch) : null,
   };
 }

--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.ts
@@ -1,12 +1,14 @@
 import { authStore } from "$lib/utils/auth.svelte";
-import { loadPlayerByUserId, loadTournament } from "../api_helper";
+import { loadCurrentRoundTimer, loadPlayerByUserId, loadTournament } from "../api_helper";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = async ({ params, fetch }) => {
   const user = await authStore.checkAuth(fetch);
+  const tournamentId = parseInt(params.tournamentId);
 
   return {
-    tournamentData: await loadTournament(parseInt(params.tournamentId), fetch),
-    player: user ? await loadPlayerByUserId(parseInt(params.tournamentId), user.id, fetch) : null,
+    tournamentData: await loadTournament(tournamentId, fetch),
+    timer: loadCurrentRoundTimer(tournamentId),
+    player: user ? await loadPlayerByUserId(tournamentId, user.id, fetch) : null,
   };
 }

--- a/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import ModalDialog from "$lib/components/ModalDialog.svelte";
   import type { RoundTimer } from "$lib/model/Round";
   import { onMount } from "svelte";
 
@@ -47,16 +48,28 @@
       clearInterval(intervalID);
     };
   });
-
-  // TODO: Fullscreen
 </script>
 
-<div class="alert {alertClass} mb-0">
-  <button class="btn btn-link alert-link p-0" style="text-decoration: none;">
-    <FontAwesomeIcon icon="clock" />
-    {millis < 0 ? "Overtime" : "Remaining"} in round{timer.paused ? " (paused)" : ""}:
-    <span class="round_time_remaining text-left alert-link" style="width: 2.6rem; display: inline-block; text-decoration: none;">
-      {minutes.toString().padStart(2, "0")}:{seconds.toString().padStart(2, "0")}
-    </span>
-  </button>
+<div>
+  <div class="alert {alertClass} mb-0">
+    <button class="btn btn-link alert-link p-0" style="text-decoration: none;" data-toggle="modal" data-target="#timerDialog">
+      <FontAwesomeIcon icon="clock" />
+      {millis < 0 ? "Overtime" : "Remaining"} in round{timer.paused ? " (paused)" : ""}:
+      <span class="text-left alert-link" style="width: 2.6rem; display: inline-block; text-decoration: none;">
+        {minutes.toString().padStart(2, "0")}:{seconds.toString().padStart(2, "0")}
+      </span>
+    </button>
+  </div>
+  
+  <ModalDialog id="timerDialog" headerText="Round Timer" dialogClass="modal-xl">
+    <p class="text-center" style="font-size: 5vw">
+      {millis < 0 ? "Overtime" : "Remaining"} in round{timer.paused ? " (paused)" : ""}:
+    </p>
+    <div class="alert alert-primary mb-0" style="font-size: 10vw; border-radius: 2vw; padding 0.5vw 4vw;">
+      <FontAwesomeIcon icon="clock-o" />
+      <span class="text-left" style="display: inline-block;">
+        {minutes.toString().padStart(2, "0")}:{seconds.toString().padStart(2, "0")}
+      </span>
+    </div>
+  </ModalDialog>
 </div>

--- a/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
@@ -62,10 +62,10 @@
   </div>
   
   <ModalDialog id="timerDialog" headerText="Round Timer" dialogClass="modal-xl">
-    <p class="text-center" style="font-size: 5vw">
+    <p class="text-center" style="font-size: 2vw">
       {millis < 0 ? "Overtime" : "Remaining"} in round{timer.paused ? " (paused)" : ""}:
     </p>
-    <div class="alert alert-primary mb-0" style="font-size: 10vw; border-radius: 2vw; padding 0.5vw 4vw;">
+    <div class="alert alert-primary mb-0" style="font-size: 12vw; border-radius: 2vw; padding 0.5vw 4vw;">
       <FontAwesomeIcon icon="clock-o" />
       <span class="text-left" style="display: inline-block;">
         {minutes.toString().padStart(2, "0")}:{seconds.toString().padStart(2, "0")}

--- a/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/RoundTimer.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import type { RoundTimer } from "$lib/model/Round";
+  import { onMount } from "svelte";
+
+  let { timer }: { timer: RoundTimer } = $props();
+
+  let millis = $state(0);
+  let minutes = $state(0);
+  let seconds = $state(0);
+  let alertClass = $state("alert-primary");
+
+  let intervalID = 0;
+
+  function updateTimer() {
+    if (timer.paused) {
+      millis = (timer.state.remaining_seconds ?? 0) * 1000;
+    } else if (timer.started) {
+      millis = new Date(timer.state.finish_time ?? "").getTime() - new Date().getTime();
+    } else {
+      millis = (timer.state.length_minutes ?? 0) * 60000;
+    }
+
+    const totalSeconds = Math.abs(Math.ceil(millis / 1000));
+    minutes = Math.min(Math.trunc(totalSeconds / 60), 99);
+    seconds = minutes > 99 ? 99 : totalSeconds % 60;
+
+    if (timer.paused) {
+      alertClass = "alert-secondary";
+    } else if (millis < 1 * 60 * 1000) {
+      alertClass = "alert-danger";
+    } else if (millis < 5 * 60 * 1000) {
+      alertClass = "alert-warning";
+    } else {
+      alertClass = "alert-primary";
+    }
+  }
+
+  onMount(() => {
+    updateTimer();
+
+    if (timer.started && intervalID === 0) {
+      intervalID = window.setInterval(updateTimer, 100);
+    }
+
+    return () => {
+      clearInterval(intervalID);
+    };
+  });
+
+  // TODO: Fullscreen
+</script>
+
+<div class="alert {alertClass} mb-0">
+  <button class="btn btn-link alert-link p-0" style="text-decoration: none;">
+    <FontAwesomeIcon icon="clock" />
+    {millis < 0 ? "Overtime" : "Remaining"} in round{timer.paused ? " (paused)" : ""}:
+    <span class="round_time_remaining text-left alert-link" style="width: 2.6rem; display: inline-block; text-decoration: none;">
+      {minutes.toString().padStart(2, "0")}:{seconds.toString().padStart(2, "0")}
+    </span>
+  </button>
+</div>

--- a/frontend/src/routes/tournaments/[tournamentId]/Tournament.svelte.test.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/Tournament.svelte.test.ts
@@ -115,6 +115,19 @@ describe("Tournament", () => {
         tournament: MockTournament,
         csrf_token: ""
       },
+      timer: {
+        show: false,
+        running: false,
+        paused: false,
+        started: false,
+        state: {
+          started: false,
+          paused: false,
+          finish_time: undefined,
+          remaining_seconds: undefined,
+          length_minutes: undefined
+        }
+      },
       player: player,
       ...dataPartial,
     },

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -180,10 +180,15 @@ export async function loadIdentityNames() {
   return (await response.json()) as IdentityNames;
 }
 
-export async function loadCurrentRoundTimer(tournamentId: number) {
+export async function loadCurrentRoundTimer(tournamentId: number, csrfToken?: string) {
   const response = await fetch(`${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/current_round_timer`, {
     method: "GET",
     credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-CSRF-Token": csrfToken ?? "",
+    },
   });
 
   return (await response.json()) as RoundTimer;

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -2,6 +2,7 @@ import { COBRA_API_SERVER } from "$app/env/public";
 import type { Card, Deck } from "$lib/model/Deck";
 import type { IdentityNames } from "$lib/model/Identity";
 import type { Player } from "$lib/model/Player";
+import type { RoundTimer } from "$lib/model/Round";
 import { Tournament, type FeatureFlags, type TournamentOptions } from "$lib/model/Tournament";
 import type { TournamentsResponse } from "$lib/utils/api_types";
 import { ValidationError, type Errors } from "$lib/utils/errors";
@@ -177,6 +178,15 @@ export async function loadIdentityNames() {
   });
 
   return (await response.json()) as IdentityNames;
+}
+
+export async function loadCurrentRoundTimer(tournamentId: number) {
+  const response = await fetch(`${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/current_round_timer`, {
+    method: "GET",
+    credentials: "include",
+  });
+
+  return (await response.json()) as RoundTimer;
 }
 
 function playerRequestObject(player: Player) {


### PR DESCRIPTION
This adds the round timer which I believe is the last major component of the tournament layout (minus the rest of the tabs). This wasn't previously implemented in Svelte because it existed outside of the bounds of the original beta Svelte pages, so this is new.

In the old pages, clicking on the round timer opens up a full screen timer with huge font for displaying on a screen. I'm currently having it open up in a `ModalDialog` as a temporary solution. Bootstrap supports full screen dialogs in v5 (we're on v4), and I haven't put effort into figuring out an elegant way to otherwise route this to bypass the layout in order to display it as a full screen page. I assume this is low enough priority for the time being.